### PR TITLE
Fix: Error when no next filter is provided with response modes

### DIFF
--- a/manager/Services.py
+++ b/manager/Services.py
@@ -318,9 +318,12 @@ class Services:
 
                 new[n]['output'] = new[n]['output']
 
-                new[n]['next_filter_unix_socket'] = '/var/sockets/darwin/{next_filter}.sock'.format(
-                    next_filter=new[n]['next_filter']
-                )
+                if not new[n]['next_filter']:
+                    new[n]['next_filter_unix_socket'] = 'no'
+                else:
+                    new[n]['next_filter_unix_socket'] = '/var/sockets/darwin/{next_filter}.sock'.format(
+                        next_filter=new[n]['next_filter']
+                    )
 
                 new[n]['socket'] = '/var/sockets/darwin/{name}{extension}.sock'.format(
                     name=n, extension=new[n]['extension']
@@ -401,9 +404,12 @@ class Services:
                     c['extension'] = '.1'
                     c['pid_file'] = '/var/run/darwin/{filter}{extension}.pid'.format(filter=f, extension=c['extension'])
 
-                    c['next_filter_unix_socket'] = '/var/sockets/darwin/{next_filter}.sock'.format(
-                        next_filter=c['next_filter']
-                    )
+                    if not c['next_filter']:
+                        c['next_filter_unix_socket'] = 'no'
+                    else:
+                        c['next_filter_unix_socket'] = '/var/sockets/darwin/{next_filter}.sock'.format(
+                            next_filter=c['next_filter']
+                        )
 
                     c['socket'] = '/var/sockets/darwin/{filter}{extension}.sock'.format(filter=f, extension=c['extension'])
                     c['socket_link'] = '/var/sockets/darwin/{filter}.sock'.format(filter=f)

--- a/samples/base/Session.cpp
+++ b/samples/base/Session.cpp
@@ -57,6 +57,12 @@ namespace darwin {
 
     void Session::SendToDarwin() noexcept {
         DARWIN_LOGGER;
+
+        if (!_next_filter_path.compare("no")) {
+            DARWIN_LOG_NOTICE("Session:: SendToDarwin: No next filter provided. Ignoring...");
+            return ;
+        }
+
         std::string data = GetDataToSendToFilter();
 
         const std::size_t certitude_size = _certitudes.size();
@@ -65,7 +71,7 @@ namespace darwin {
         packet = (darwin_filter_packet_t *) malloc(offsetof(darwin_filter_packet_t, certitude_list[certitude_size]));
 
         if (!packet) {
-            DARWIN_LOG_CRITICAL("Session:: SendResToSession: Could not create a Darwin packet");
+            DARWIN_LOG_CRITICAL("Session:: SendToDarwin: Could not create a Darwin packet");
             return;
         }
 


### PR DESCRIPTION
Resolve #36 

When no next_filter is provided, set the filter parameter to `no`.

When the next filter socket path is equal to `no` in a filter, no longer tries to connect to it.
Outputs a Notice level log.

Corrected a log line.