### PR TITLE
launch HeartBeat at startup and improve filters restart/update

### DIFF
--- a/manager/manager.py
+++ b/manager/manager.py
@@ -112,9 +112,10 @@ if __name__ == '__main__':
         exit(1)
 
     t = Thread(target=server.constant_heartbeat, args=(services,))
+    logger.info("launching HeartBeat thread...")
+    t.start()
     logger.info("Running server...")
     server.run(services)
-    t.start()
 
     logger.info("Stopping services...")
     logger.debug("Joining...")


### PR DESCRIPTION
PLEASE MERGE AFTER #46 

launches HeartBeat at manager startup
manager tries to restart filters if they fail at startup, stops after 3 times
handles updates correctly, permits to start previously failed filters