### PR TITLE
Changes to Core and manager/heartbeat (Fixes #77)

### DIFF
--- a/manager/Services.py
+++ b/manager/Services.py
@@ -28,7 +28,7 @@ from threading import Lock
 from copy import deepcopy
 from subprocess import Popen, call, TimeoutExpired
 from os import kill, remove, access, F_OK
-from signal import SIGTERM, SIGUSR1
+from signal import SIGTERM, SIGUSR1, SIGKILL
 from pprint import pprint
 from JsonSocket import JsonSocket
 from HeartBeat import HeartBeat
@@ -61,6 +61,14 @@ class Services:
         with self._lock:
             for _, filter in self._filters.items():
                 self.start_one(filter, True)
+                ret = Services._wait_process_ready(filter)
+                if ret:
+                    logger.error("Error when starting filter {}: {}".format(filter['name'], ret))
+                    self.stop_one(filter, no_lock=True)
+                    self.clean_one(filter, no_lock=True)
+                else:
+                    filter['status'] = psutil.STATUS_RUNNING
+                    call(['ln', '-s', filter['socket'], filter['socket_link']])
 
     def rotate_logs_all(self):
         """
@@ -81,6 +89,7 @@ class Services:
             for _, filter in self._filters.items():
                 try:
                     self.stop_one(filter, True)
+                    self.clean_one(filter, True)
                 except Exception:
                     pass
 
@@ -165,6 +174,7 @@ class Services:
         logger.debug("Pid read : {}".format(pid))
         kill(int(pid), SIGTERM)
         logger.debug("SIGTERM sent")
+        return int(pid)
 
     def start_one(self, filter, no_lock=False):
         """
@@ -178,8 +188,6 @@ class Services:
             self._lock.acquire()
 
         cmd = self._build_cmd(filter)
-        call(['ln', '-s', filter['socket'],
-              filter['socket_link']])
 
         if not no_lock:
             self._lock.release()
@@ -199,8 +207,6 @@ class Services:
                 p.wait()
                 filter['status'] = psutil.STATUS_DEAD
                 return
-
-        filter['status'] = psutil.STATUS_RUNNING
 
     @staticmethod
     def rotate_logs(name, pid_file):
@@ -240,18 +246,32 @@ class Services:
         :param pid_file: The pid file of the filter.
         :param socket_link: The symlink to the filter socket (Optional).
         """
+        pid = None
+
         try:
-            Services._kill_with_pid_file(pid_file)
+            pid = Services._kill_with_pid_file(pid_file)
         except FileNotFoundError as e:
-            logger.warning("No PID found for {}. Did the filter start/crash?".format(name))
+            logger.warning("No PID file found for {}. Did the filter start/crash?".format(name))
             for proc in psutil.process_iter(attrs=["cmdline", "name", "pid"]):
                 if name in proc.info["cmdline"] and "darwin_" in proc.info["name"]:
                     logger.warning("Filter {} found in running processes (pid {}). Killing.".format(name, proc.info['pid']))
                     kill(proc.info['pid'], SIGTERM)
-                    sleep(2)
+                    pid = proc.info['pid']
 
         except Exception as e:
             logger.error("Cannot stop filter {}: {}".format(name, e))
+
+        if pid:
+            tries = 0
+            proc_running = HeartBeat.check_process(pid)
+            while tries < 10 and proc_running:
+                sleep(1)
+                proc_running = HeartBeat.check_process(pid)
+                tries += 1
+
+            if proc_running:
+                logger.warning("filter {} did not stop, forcing.".format(name))
+                kill(int(pid), SIGKILL)
 
         if not socket_link:
             return
@@ -271,6 +291,8 @@ class Services:
         """
         if not no_lock:
             self._lock.acquire()
+
+        filter['status'] = psutil.STATUS_TRACING_STOP
 
         self.stop(filter['name'], filter['pid_file'],
                   filter['socket_link'])
@@ -292,7 +314,6 @@ class Services:
         except Exception as e:
             logger.error("Cannot stop filter {}: {}".format(filter['name'], e))
 
-        sleep(1)
         try:
             self.clean_one(filter, no_lock=no_lock)
         except Exception as e:
@@ -303,13 +324,14 @@ class Services:
         except Exception as e:
             logger.error("Cannot start filter {}: {}".format(filter['name'], e))
 
-        ret = Services._update_check_process(filter)
+        ret = Services._wait_process_ready(filter)
         if ret:
             logger.error("Error when starting filter {}: {}".format(filter['name'], ret))
+            self.stop_one(filter, no_lock=no_lock)
             self.clean_one(filter, no_lock=no_lock)
         else:
             filter['status'] = psutil.STATUS_RUNNING
-            filter['failures'] = 0
+            call(['ln', '-s', filter['socket'], filter['socket_link']])
 
     def update(self, names):
         """
@@ -403,7 +425,6 @@ class Services:
 
             for n, c in new.items():
                 c['status'] = psutil.STATUS_WAKING
-                c['failures'] = 0
                 cmd = self._build_cmd(c)
                 logger.info("Starting updated filter")
                 p = Popen(cmd)
@@ -416,7 +437,7 @@ class Services:
                         logger.error("Error starting filter. Did not daemonize before timeout. Killing it.")
                         p.kill()
                         p.wait()
-                ret = Services._update_check_process(c)
+                ret = Services._wait_process_ready(c)
                 if ret:
                     logger.error("Unable to update filter {}: {}".format(n, ret))
                     # Then there is an error
@@ -445,14 +466,12 @@ class Services:
                     continue
 
                 try:
-                    if self._filters[n]['status'] != psutil.STATUS_STOPPED:
-                        logger.info("Killing older filter...")
-                        Services.stop(n, self._filters[n]['pid_file'])
-                        logger.debug("{} with PID {} killed.".format(n, self._filters[n]['pid_file']))
-                        self.clean_one(self._filters[n], no_lock=True)
-                        logger.debug("Cleaned filter")
+                    logger.info("Killing older filter...")
+                    # Call 'stop' instead of 'stop_one' to avoid deletion of socket_link
+                    self.stop(n, self._filters[n]['pid_file'])
+                    self.clean_one(self._filters[n], no_lock=True)
                 except KeyError:
-                    logger.debug("Key error when trying to kill with PID")
+                    logger.info("no older filter to kill, finalizing...")
                     pass
                 self._filters[n] = deepcopy(c)
                 logger.info("successfully updated {}".format(n))
@@ -484,7 +503,6 @@ class Services:
 
                 try:
                     c['name'] = f
-                    c['failures'] = 0
                     c['status'] = psutil.STATUS_WAKING
                     c['extension'] = '.1'
                     c['pid_file'] = '/var/run/darwin/{filter}{extension}.pid'.format(filter=f, extension=c['extension'])
@@ -578,21 +596,22 @@ class Services:
         return monitor_data
 
     @staticmethod
-    def _update_check_process(content):
+    def _wait_process_ready(content):
         """
-        Check that the passed process is up.
+        Check that the passed process is up and running.
 
         :param content: Dict containing the filter configuration.
         :return: None on success, a str containing the error message on error.
         """
-        logger.debug("entered _update_check_process")
-        retries = 1
+        logger.debug("entered _wait_process_ready")
+        retries = 0
         status = "Not None"
-        while status and retries <= 3:
-            sleep(0.2)
+        while status and retries < 3:
             retries += 1
             status = None
+            sleep(0.2)
             pid = HeartBeat.check_pid_file(content['pid_file'])
+
             if not pid:
                 status = "PID file not accessible"
                 continue
@@ -601,16 +620,30 @@ class Services:
                 status = "Process not running"
                 continue
 
-            if not HeartBeat.check_socket(content['socket']):
-                status = "Main socket not created"
-                continue
-
             if not HeartBeat.check_socket(content['monitoring']):
                 status = "Monitoring socket not created"
                 continue
 
-            if Services.monitor_one(content['monitoring']) is None:
+        if status:
+            return status
+
+        status = "Not None"
+        retries = 0
+        while status and retries < 10:
+            status = None
+            retries += 1
+            sleep(1)
+            resp = Services._get_monitoring_info(content['monitoring'])
+            if not resp:
                 status = "Monitoring socket not ready"
+                continue
+
+            if "running" in resp:
+                if not HeartBeat.check_socket(content['socket']):
+                    status = "Main socket not created"
+                    continue
+            else:
+                status = "Filter not ready"
                 continue
 
         return status
@@ -633,15 +666,11 @@ class Services:
             if not HeartBeat.check_socket(filter['socket']):
                 raise Exception('Socket not accessible')
 
+            if not HeartBeat.check_socket(filter['monitoring']):
+                raise Exception('Monitoring socket not accessible')
+
         except Exception as e:
             logger.warning("HeartBeat failed on {} ({}). Restarting the filter.".format(filter['name'], e))
-            filter['failures']  += 1
-            if filter['failures'] > 3:
-                logger.error('Too many failures when starting {}. Filter stopped.'.format(filter['name']))
-                self.stop_one(filter, no_lock=True)
-                sleep(1)
-                self.clean_one(filter, no_lock=True)
-                return
             filter['status'] = psutil.STATUS_DEAD
             self.restart_one(filter, no_lock=True)
 
@@ -684,3 +713,30 @@ class Services:
         with self._lock:
             for _, c in self._filters.items():
                 self.clean_one(c, no_lock=True)
+
+    @staticmethod
+    def _get_monitoring_info(socket_path):
+        """
+        Sends a request to a socket and returns the answer.
+        :param request: the binary formatted request
+        :param socket_path: the fullpath to the socket file
+        :return: the answer as a string or None if no answer could be received
+        """
+
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+
+        try:
+            sock.connect(socket_path)
+        except socket.error:
+            return None
+        try:
+            sock.sendall(b'')
+        except Exception:
+            return None
+
+        try:
+            response = sock.recv(4096).decode()
+        except Exception:
+            return None
+
+        return response

--- a/samples/base/Core.cpp
+++ b/samples/base/Core.cpp
@@ -19,29 +19,34 @@ namespace darwin {
 
     Core::Core()
             : _name{}, _socketPath{}, _modConfigPath{}, _monSocketPath{},
-              _pidPath{}, _nbThread{0}, daemon{true} {}
+              _pidPath{}, _nbThread{0}, daemon{true}, _filter_status{FilterStatusEnum::starting} {}
 
     int Core::run() {
         DARWIN_LOGGER;
         int ret{0};
 
-       Generator gen{};
-        if (!gen.Configure(_modConfigPath, _cacheSize)) {
-            DARWIN_LOG_CRITICAL("Core:: Run:: Unable to configure the filter");
-            return 1;
-        }
-        DARWIN_LOG_DEBUG("Core::run:: Configured generator");
-
         try {
-            Monitor monitor{_monSocketPath};
+            Monitor monitor{_monSocketPath, _filter_status};
             std::thread t{std::bind(&Monitor::Run, std::ref(monitor))};
+
+            _filter_status.store(FilterStatusEnum::configuring);
+            Generator gen{};
+            if (!gen.Configure(_modConfigPath, _cacheSize)) {
+                DARWIN_LOG_CRITICAL("Core:: Run:: Unable to configure the filter");
+                raise(SIGTERM);
+                t.join();
+                return 1;
+            }
+            DARWIN_LOG_DEBUG("Core::run:: Configured generator");
 
             try {
                 Server server{_socketPath, _output, _nextFilterUnixSocketPath, _nbThread, _threshold, gen};
+                _filter_status.store(FilterStatusEnum::running);
                 server.Run();
             } catch (const std::exception& e) {
                 DARWIN_LOG_CRITICAL(std::string("Core::run:: Cannot open unix socket: ") + e.what());
                 ret = 1;
+                raise(SIGTERM);
             }
 
             if (t.joinable())

--- a/samples/base/Core.hpp
+++ b/samples/base/Core.hpp
@@ -9,6 +9,7 @@
 
 #include <thread>
 #include "Monitor.hpp"
+#include <boost/atomic.hpp>
 
 #ifndef PID_PATH
 # define PID_PATH "/var/run/darwin/"
@@ -76,6 +77,8 @@ namespace darwin {
         std::size_t _nbThread;
         std::size_t _cacheSize;
         std::size_t _threshold;
+        boost::atomic<FilterStatusEnum> _filter_status;
+
 
     public:
         // TODO Maybe a getter is a better idea...

--- a/samples/base/Core.hpp
+++ b/samples/base/Core.hpp
@@ -9,7 +9,7 @@
 
 #include <thread>
 #include "Monitor.hpp"
-#include <boost/atomic.hpp>
+#include <atomic>
 
 #ifndef PID_PATH
 # define PID_PATH "/var/run/darwin/"
@@ -77,7 +77,7 @@ namespace darwin {
         std::size_t _nbThread;
         std::size_t _cacheSize;
         std::size_t _threshold;
-        boost::atomic<FilterStatusEnum> _filter_status;
+        std::atomic<FilterStatusEnum> _filter_status;
 
 
     public:

--- a/samples/base/Monitor.cpp
+++ b/samples/base/Monitor.cpp
@@ -10,7 +10,7 @@
 #include "Logger.hpp"
 
 namespace darwin {
-    Monitor::Monitor(std::string const& unix_socket_path, boost::atomic<FilterStatusEnum>& status)
+    Monitor::Monitor(std::string const& unix_socket_path, std::atomic<FilterStatusEnum>& status)
             : _socket_path{unix_socket_path}, _io_context{1},
               _signals{_io_context},
               _acceptor{_io_context,

--- a/samples/base/Monitor.cpp
+++ b/samples/base/Monitor.cpp
@@ -10,12 +10,14 @@
 #include "Logger.hpp"
 
 namespace darwin {
-    Monitor::Monitor(std::string const& unix_socket_path)
+    Monitor::Monitor(std::string const& unix_socket_path, boost::atomic<FilterStatusEnum>& status)
             : _socket_path{unix_socket_path}, _io_context{1},
               _signals{_io_context},
               _acceptor{_io_context,
                         boost::asio::local::stream_protocol::endpoint(
-                                _socket_path)}, _connection{_io_context} {
+                                _socket_path)},
+              _connection{_io_context},
+              _filter_status{status} {
         // Setting the stopping signals for the service
         _signals.add(SIGINT);
         _signals.add(SIGTERM);
@@ -88,7 +90,16 @@ namespace darwin {
     }
 
     void Monitor::SendMonitoringData() {
-        boost::asio::async_write(_connection, boost::asio::buffer("{}"),
+        std::string message("{\"status\": ");
+        switch(_filter_status) {
+            case FilterStatusEnum::starting : message.append("\"starting\"");   break;
+            case FilterStatusEnum::configuring : message.append("\"configuring\"");    break;
+            case FilterStatusEnum::running : message.append("\"running\""); break;
+            default: message.append("\"unknown\"");
+        }
+        message.append("}");
+
+        boost::asio::async_write(_connection, boost::asio::buffer(message),
                                  boost::bind(&Monitor::HandleSend, this,
                                              boost::asio::placeholders::error,
                                              boost::asio::placeholders::bytes_transferred));

--- a/samples/base/Monitor.hpp
+++ b/samples/base/Monitor.hpp
@@ -9,7 +9,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
-#include <boost/atomic.hpp>
+#include <atomic>
 
 enum class FilterStatusEnum {starting, configuring, running};
 
@@ -26,7 +26,7 @@ namespace darwin {
         /// Constructor.
         ///
         /// \param unix_socket_path The path to the unix socket to connect to the management API.
-        explicit Monitor(std::string const& unix_socket_path, boost::atomic<FilterStatusEnum>& status);
+        explicit Monitor(std::string const& unix_socket_path, std::atomic<FilterStatusEnum>& status);
         ~Monitor() = default;
 
     public:
@@ -67,6 +67,6 @@ namespace darwin {
         boost::asio::signal_set _signals; //!< Set of the stopping signals.
         boost::asio::local::stream_protocol::acceptor _acceptor; //!< Acceptor for the incoming connections.
         boost::asio::local::stream_protocol::socket _connection; //!< Socket of the current connection.
-        boost::atomic<FilterStatusEnum>& _filter_status; //!< Current status of the filter.
+        std::atomic<FilterStatusEnum>& _filter_status; //!< Current status of the filter.
     };
 }

--- a/samples/base/Monitor.hpp
+++ b/samples/base/Monitor.hpp
@@ -9,6 +9,9 @@
 
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
+#include <boost/atomic.hpp>
+
+enum class FilterStatusEnum {starting, configuring, running};
 
 /// \namespace darwin
 namespace darwin {
@@ -23,7 +26,7 @@ namespace darwin {
         /// Constructor.
         ///
         /// \param unix_socket_path The path to the unix socket to connect to the management API.
-        explicit Monitor(std::string const& unix_socket_path);
+        explicit Monitor(std::string const& unix_socket_path, boost::atomic<FilterStatusEnum>& status);
         ~Monitor() = default;
 
     public:
@@ -64,5 +67,6 @@ namespace darwin {
         boost::asio::signal_set _signals; //!< Set of the stopping signals.
         boost::asio::local::stream_protocol::acceptor _acceptor; //!< Acceptor for the incoming connections.
         boost::asio::local::stream_protocol::socket _connection; //!< Socket of the current connection.
+        boost::atomic<FilterStatusEnum>& _filter_status; //!< Current status of the filter.
     };
 }

--- a/tests/core/base.py
+++ b/tests/core/base.py
@@ -5,6 +5,7 @@ from time import sleep
 from tools.filter import Filter
 from tools.output import print_result
 from core.utils import DEFAULT_PATH
+from manager_socket.utils import RESP_MON_STATUS_RUNNING
 from darwin import DarwinApi
 
 
@@ -141,9 +142,9 @@ def check_socket_monitor_connection():
     try:
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
             s.connect(filter.monitor)
-            data = s.recv(4096)
+            data = s.recv(4096).decode()
             s.close()
-        if data != b'{}\x00':
+        if RESP_MON_STATUS_RUNNING not in data:
             logging.error("check_socket_monitor_connection: Wrong response; got {}".format(data))
             return False
     except Exception as e:

--- a/tests/manager_socket/utils.py
+++ b/tests/manager_socket/utils.py
@@ -147,8 +147,8 @@ REQ_UPDATE_NON_EXISTING = b'{"type": "update_filters", "filters": ["tototititata
 # Responses
 
 RESP_EMPTY     = '{}'
-RESP_ONE       = '{"logs_1": {}}'
-RESP_THREE     = '{"logs_1": {}, "logs_2": {}, "logs_3": {}}'
+RESP_ONE       = '{"logs_1": {"status": "running"}}'
+RESP_THREE     = '{"logs_1": {"status": "running"}, "logs_2": {"status": "running"}, "logs_3": {"status": "running"}}'
 RESP_STATUS_OK = '{"status": "OK"}'
 RESP_STATUS_KO_GEN = '{"status": "KO"'
 RESP_STATUS_KO_NO_PID = '{"status": "KO", "errors": [{"filter": "logs_1", "error": "PID file not accessible"}]}'
@@ -162,3 +162,7 @@ RESP_STATUS_KO_LIST = [ RESP_STATUS_KO_NO_PID,
                         RESP_STATUS_KO_NO_MON_SOCK,
                         RESP_STATUS_KO_NO_MON_SOCK_NREADY]
 RESP_FILTER_NOT_EXISTING = '{"status": "KO", "errors": [{"filter": "tototititata", "error": "Filter not existing"}]}'
+
+RESP_MON_STATUS_STARTING = '"status: "starting"'
+RESP_MON_STATUS_CONFIGURING = '"status": "configuring"'
+RESP_MON_STATUS_RUNNING = '"status": "running"'


### PR DESCRIPTION
#Changes to Core
- Start Monitor before reading/generating filter configuration
- Close Monitor gracefully before finishing in case of configuration error
- Monitor returns filter's state (starting, configuring, running)

#Changes to manager/heartbeat
- during startup: check that filter is correctly started
- during stop: check that filter is correctly stopped
- removed heartbeat retries on restarting filters (now filters are either correctly started/restarted or faulty)