### PR TITLE
Change sprintf function into snprintf

### DIFF
--- a/samples/base/Session.cpp
+++ b/samples/base/Session.cpp
@@ -481,7 +481,8 @@ namespace darwin {
 
     std::string Session::Evt_idToString() {
         char str[37] = {};
-        sprintf(str,
+        snprintf(str,
+                37,
                 "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
                 header.evt_id[0], header.evt_id[1], header.evt_id[2], header.evt_id[3],
                 header.evt_id[4], header.evt_id[5], header.evt_id[6], header.evt_id[7],


### PR DESCRIPTION
# :sparkles: Change sprintf int snprintf

:bangbang: Once all the **checklist** is **done** you have to:
  * **stash merge** this pull request 
  * **delete** the corresponding **branch** 
  * **close** the associated **issue**

## :black_nib: Description

In Session.cpp change sprintf function into snprintf for convert evt_id to string

**Tested under:**
- **FreeBSD 12.0**
  - Boost 1.70.0
  - clang++ 6.0.1
  - CMake 3.14.5
  - Python 3.6.9

- **Ubuntu 18.04**
  - Boost 1.70.0
  - g++ 8.3.0
  - CMake 3.10.2
  - Valgrind 3.13.0

Resolve #64 

## :page_with_curl: Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## :heavy_check_mark: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the 
- [x] New and existing unit tests pass locally with my changes

</br>

- [x] :raising_hand: **I certify on my honor that all the informations provided are true, and I've done all I can to deliver a high quality code**
