### PR TITLE
FIX: HOSTLOOKUP TESTS MISSING

### DIFF
--- a/tests/core/base.py
+++ b/tests/core/base.py
@@ -4,12 +4,11 @@ from os import kill, remove, access, F_OK
 from time import sleep
 from tools.filter import Filter
 from tools.output import print_result
-from core.utils import DEFAULT_PATH
-from manager_socket.utils import RESP_MON_STATUS_RUNNING
+from core.utils import DEFAULT_PATH, FLOGS_CONFIG, RESP_MON_STATUS_RUNNING
 from darwin import DarwinApi
 
 
-FLOGS_CONFIG = '{"log_file_path": "/tmp/logs_test.log"}'
+
 
 def run():
     tests = [

--- a/tests/core/utils.py
+++ b/tests/core/utils.py
@@ -2,3 +2,5 @@ from conf import DEFAULT_FILTER_PATH
 
 
 DEFAULT_PATH = DEFAULT_FILTER_PATH + "darwin_logs"
+RESP_MON_STATUS_RUNNING = '{"status": "running"}'
+FLOGS_CONFIG = '{"log_file_path": "/tmp/logs_test.log"}'

--- a/tests/filters/fhostlookup.py
+++ b/tests/filters/fhostlookup.py
@@ -41,7 +41,7 @@ def run():
     ]
 
     for i in tests:
-        print_result("hostlookup: " + i.__name__, i())
+        print_result("hostlookup: " + i.__name__, i)
 
 
 def test(test_name, init_data, data, expected_certitudes, expected_certitudes_size):

--- a/tests/filters/flogs.py
+++ b/tests/filters/flogs.py
@@ -94,7 +94,7 @@ def run():
     ]
 
     for i in tests:
-        print_result("logs: " + i.__name__, i())
+        print_result("logs: " + i.__name__, i)
 
 
 def single_log_to_file():

--- a/tests/filters/test.py
+++ b/tests/filters/test.py
@@ -1,5 +1,6 @@
 import filters.flogs as flogs
 import filters.fconnection as fconnection
+import filters.fhostlookup as fhostlookup
 from tools.output import print_results
 
 
@@ -8,6 +9,7 @@ def run():
 
     fconnection.run()
     flogs.run()
+    fhostlookup.run()
 
     print()
     print()


### PR DESCRIPTION
Added missing hostlookup tests to the filters.test module.

Added missing variable for core testing.
Moved a global variable to the utils.py of the core tests.

Fix flogs testing calling function instead of passing a reference to it.