### PR TITLE
HOTFIX:: keep starting other filters when one fails at startup

### DIFF
--- a/manager/Services.py
+++ b/manager/Services.py
@@ -60,15 +60,15 @@ class Services:
         """
         with self._lock:
             for _, filter in self._filters.items():
-                self.start_one(filter, True)
-                ret = Services._wait_process_ready(filter)
-                if ret:
-                    logger.error("Error when starting filter {}: {}".format(filter['name'], ret))
-                    self.stop_one(filter, no_lock=True)
-                    self.clean_one(filter, no_lock=True)
-                else:
-                    filter['status'] = psutil.STATUS_RUNNING
-                    call(['ln', '-s', filter['socket'], filter['socket_link']])
+                if self.start_one(filter, True):
+                    ret = Services._wait_process_ready(filter)
+                    if ret:
+                        logger.error("Error when starting filter {}: {}".format(filter['name'], ret))
+                        self.stop_one(filter, no_lock=True)
+                        self.clean_one(filter, no_lock=True)
+                    else:
+                        filter['status'] = psutil.STATUS_RUNNING
+                        call(['ln', '-s', filter['socket'], filter['socket_link']])
 
     def rotate_logs_all(self):
         """
@@ -195,7 +195,12 @@ class Services:
         # start process
         logger.debug("Starting {}".format(" ".join(cmd)))
         filter['status'] = psutil.STATUS_WAKING
-        p = Popen(cmd)
+
+        try:
+            p = Popen(cmd)
+        except OSError as e:
+            logger.error("cannot start filter: " + str(e))
+            return False
         try:
             p.wait(timeout=1)
         except TimeoutExpired:
@@ -206,7 +211,9 @@ class Services:
                 p.kill()
                 p.wait()
                 filter['status'] = psutil.STATUS_DEAD
-                return
+                return False
+
+        return True
 
     @staticmethod
     def rotate_logs(name, pid_file):

--- a/manager/Services.py
+++ b/manager/Services.py
@@ -200,6 +200,7 @@ class Services:
             p = Popen(cmd)
         except OSError as e:
             logger.error("cannot start filter: " + str(e))
+            filter['status'] = psutil.STATUS_DEAD
             return False
         try:
             p.wait(timeout=1)

--- a/tests/manager_socket/monitor_test.py
+++ b/tests/manager_socket/monitor_test.py
@@ -1,4 +1,4 @@
-from manager_socket.utils import requests, CONF_EMPTY, CONF_FLOGS, CONF_ONE, CONF_THREE, REQ_MONITOR, RESP_EMPTY, RESP_LOGS_1, RESP_LOGS_2, RESP_LOGS_3, PATH_CONF_FLOGS
+from manager_socket.utils import requests, CONF_EMPTY, CONF_FLOGS, CONF_ONE, CONF_THREE, CONF_THREE_ONE_WRONG, REQ_MONITOR, RESP_EMPTY, RESP_LOGS_1, RESP_LOGS_2, RESP_LOGS_3, PATH_CONF_FLOGS
 from tools.darwin_utils import darwin_configure, darwin_remove_configuration, darwin_start, darwin_stop
 from tools.output import print_result
 
@@ -6,6 +6,7 @@ from tools.output import print_result
 def run():
     tests = [
         multiple_filters_running,
+		multiple_filters_running_one_fail,
         one_filters_running,
         no_filter,
     ]
@@ -31,6 +32,22 @@ def multiple_filters_running():
     darwin_remove_configuration(path=PATH_CONF_FLOGS)
     return ret
 
+def multiple_filters_running_one_fail():
+
+    ret = False
+
+    darwin_configure(CONF_THREE_ONE_WRONG)
+    darwin_configure(CONF_FLOGS, path=PATH_CONF_FLOGS)
+    process = darwin_start()
+
+    resp = requests(REQ_MONITOR)
+    if all(x in resp for x in [RESP_LOGS_1, RESP_LOGS_3]):
+        ret = True
+
+    darwin_stop(process)
+    darwin_remove_configuration()
+    darwin_remove_configuration(path=PATH_CONF_FLOGS)
+    return ret
 
 def one_filters_running():
 

--- a/tests/manager_socket/utils.py
+++ b/tests/manager_socket/utils.py
@@ -127,6 +127,36 @@ CONF_THREE = """{{
     }}
 }}
 """.format(DEFAULT_FILTER_PATH, PATH_CONF_FLOGS)
+CONF_THREE_ONE_WRONG = """{{
+  "logs_1": {{
+        "exec_path": "{0}darwin_logs",
+        "config_file":"{1}",
+        "output": "NONE",
+        "next_filter": "",
+        "nb_thread": 1,
+        "log_level": "DEBUG",
+        "cache_size": 0
+    }},
+    "logs_2": {{
+        "exec_path": "wrong_path",
+        "config_file":"{1}",
+        "output": "NONE",
+        "next_filter": "",
+        "nb_thread": 1,
+        "log_level": "DEBUG",
+        "cache_size": 0
+    }},
+    "logs_3": {{
+        "exec_path": "{0}darwin_logs",
+        "config_file":"{1}",
+        "output": "NONE",
+        "next_filter": "",
+        "nb_thread": 1,
+        "log_level": "DEBUG",
+        "cache_size": 0
+    }}
+}}
+""".format(DEFAULT_FILTER_PATH, PATH_CONF_FLOGS)
 CONF_FLOGS = """{
     "log_file_path": "/tmp/logs_test.log"
 }"""


### PR DESCRIPTION
Fix #114.
Catch OSError when trying to launch executable, and return start status for subsequent processing.