### PR TITLE
Version 1.1.1

### DIFF
--- a/samples/base/Core.cpp
+++ b/samples/base/Core.cpp
@@ -199,4 +199,8 @@ namespace darwin {
         return true;
     }
 
+    const std::string& Core::GetFilterName() {
+        return this->_name;
+    }
+
 }

--- a/samples/base/Core.hpp
+++ b/samples/base/Core.hpp
@@ -67,6 +67,11 @@ namespace darwin {
         /// \return true on success, false otherwise.
         static bool GetULArg(unsigned long& res, const char* arg);
 
+        /// Getter for the filter name.
+        ///
+        /// \return A const reference to the string containing the unique name given in the program arguments.
+        const std::string& GetFilterName();
+
     private:
         std::string _name;
         std::string _socketPath;

--- a/samples/ftanomaly/Generator.cpp
+++ b/samples/ftanomaly/Generator.cpp
@@ -73,6 +73,19 @@ bool Generator::LoadConfig(const rapidjson::Document &configuration) {
             return false;
         }
 
+        if(not redis_alerts_list.compare(REDIS_INTERNAL_LIST)) {
+            redis_alerts_list.clear();
+            if(not redis_alerts_channel.empty()) {
+                DARWIN_LOG_WARNING("TAnomaly:: Generator:: \"redis_list_name\" parameter cannot be set to '" +
+                                    std::string(REDIS_INTERNAL_LIST) + "' (forbidden name), parameter ignored.");
+            }
+            else {
+                DARWIN_LOG_ERROR("TAnomaly:: Generator:: \"redis_list_name\" parameter cannot be set to '" +
+                                std::string(REDIS_INTERNAL_LIST) + "' (forbidden name). No alternative for Redis, aborting.");
+                return false;
+            }
+        }
+
         DARWIN_LOG_INFO("TAnomaly:: Generator:: Redis configured successfuly");
     }
 

--- a/samples/ftanomaly/Generator.cpp
+++ b/samples/ftanomaly/Generator.cpp
@@ -6,6 +6,7 @@
 /// \brief    Copyright (c) 2018 Advens. All rights reserved.
 
 #include "base/Logger.hpp"
+#include "base/Core.hpp"
 #include "Generator.hpp"
 #include "TAnomalyTask.hpp"
 #include "TAnomalyThreadManager.hpp"
@@ -18,6 +19,9 @@
 bool Generator::LoadConfig(const rapidjson::Document &configuration) {
     DARWIN_LOGGER;
     DARWIN_LOG_DEBUG("TAnomaly:: Generator:: Loading configuration...");
+
+    // Generating name for the internaly used redis set
+    _redis_internal = darwin::Core::instance().GetFilterName() + REDIS_INTERNAL_LIST;
 
     std::string redis_alerts_channel; //the channel on which to publish alerts when detected
     std::string redis_alerts_list; //the list on which to add alerts when detected
@@ -73,15 +77,15 @@ bool Generator::LoadConfig(const rapidjson::Document &configuration) {
             return false;
         }
 
-        if(not redis_alerts_list.compare(REDIS_INTERNAL_LIST)) {
+        if(not redis_alerts_list.compare(_redis_internal)) {
             redis_alerts_list.clear();
             if(not redis_alerts_channel.empty()) {
                 DARWIN_LOG_WARNING("TAnomaly:: Generator:: \"redis_list_name\" parameter cannot be set to '" +
-                                    std::string(REDIS_INTERNAL_LIST) + "' (forbidden name), parameter ignored.");
+                                    std::string(_redis_internal) + "' (forbidden name), parameter ignored.");
             }
             else {
                 DARWIN_LOG_ERROR("TAnomaly:: Generator:: \"redis_list_name\" parameter cannot be set to '" +
-                                std::string(REDIS_INTERNAL_LIST) + "' (forbidden name). No alternative for Redis, aborting.");
+                                std::string(_redis_internal) + "' (forbidden name). No alternative for Redis, aborting.");
                 return false;
             }
         }

--- a/samples/ftanomaly/Generator.hpp
+++ b/samples/ftanomaly/Generator.hpp
@@ -17,6 +17,8 @@
 #include "TAnomalyThreadManager.hpp"
 #include "AGenerator.hpp"
 
+#define REDIS_INTERNAL_LIST "anomalyFilter_internal"
+
 class Generator: public AGenerator {
 public:
     Generator() = default;
@@ -31,6 +33,6 @@ private:
     virtual bool LoadConfig(const rapidjson::Document &configuration) override final;
 
     std::shared_ptr<darwin::toolkit::FileManager> _log_file = nullptr;
-    std::string _redis_internal = "anomalyFilterData";
+    std::string _redis_internal = REDIS_INTERNAL_LIST;
     std::shared_ptr<AnomalyThreadManager> _anomaly_thread_manager;
 };

--- a/samples/ftanomaly/Generator.hpp
+++ b/samples/ftanomaly/Generator.hpp
@@ -17,7 +17,7 @@
 #include "TAnomalyThreadManager.hpp"
 #include "AGenerator.hpp"
 
-#define REDIS_INTERNAL_LIST "anomalyFilter_internal"
+#define REDIS_INTERNAL_LIST "_anomalyFilter_internal"
 
 class Generator: public AGenerator {
 public:


### PR DESCRIPTION
# HOTFIX: TAnomaly conflicting Redis set name

## TAnomaly

- Redis set name is generated using the "name" attribute of the program.
- If the generated name and the given list name for the alerts are identical, the given name is ignored and a warning is logged.