### PR TITLE
Be more permissive during conf v1 parse, add redis to tests requirements

### DIFF
--- a/manager/config.py
+++ b/manager/config.py
@@ -46,21 +46,37 @@ conf_v1_schema = {
                 "exec_path": {"type": "string"},
                 "config_file": {"type": "string"},
                 "nb_thread": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 100,
-                    "default": 5
-                    },
+                    "oneOf": [
+                        {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 100,
+                            "default": 5
+                        },
+                        {
+                            "type": "string",
+                            "pattern": "^[1]?[0-9]{0,2}$"
+                        }
+                    ]
+                },
                 "log_level": {
                     "type": "string",
                     "enum": ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "DEVELOPER"],
                     "default": "WARNING"
                     },
                 "cache_size": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "default": 0
-                    },
+                    "oneOf": [
+                        {
+                            "type": "integer",
+                            "minimum": 0,
+                            "default": 0
+                        },
+                        {
+                            "type": "string",
+                            "pattern": "^[0-9]+$"
+                        }
+                    ]
+                },
                 "output": {
                     "type": "string",
                     "enum": ["NONE", "RAW", "LOG", "PARSED"],

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,1 +1,2 @@
 git+https://github.com/VultureProject/darwin-client-python.git
+redis=3.3.11


### PR DESCRIPTION
# :sparkles: Pull Request Template
:bangbang: Once all the **checklist** is **done** you have to:
  * **stash merge** this pull request
  * **delete** the corresponding **branch**
  * **close** the associated **issue**

## :page_with_curl: Type of change

Please delete options that are not relevant.

**Bug fix**: non-breaking change which fixes an issue.

## :bulb: Related Issue(s)

## :black_nib: Description
- Allow fields 'nb_thread' and 'cache_size' to be strings (but still make sure they are valid numbers) -> allows legacy Vulture confs to still work
- Add  redis 3.3.11 to tests python requirements

## :dart: Test Environments

### FreeBSD 12.0
- Redis 4.0.14
- Boost 1.71
- g++ 8.3.0
- CMake 3.15.3
- Python 3.6.9

### Ubuntu 18.04
- Redis 4.0.9
- Boost 1.70
- g++ 7.4.0
- CMake 3.10.2
- Python 3.6.9
- Valgrind 3.13.0

## :heavy_check_mark: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] (**If other changes**) I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

</br>

- [x] :raising_hand: **I certify on my honor that all the information provided is true, and I've done all I can to deliver a high quality code**
