### PR TITLE
Add configurable darwin files paths

### DIFF
--- a/manager/Administration.py
+++ b/manager/Administration.py
@@ -10,12 +10,11 @@ import socket
 import logging
 import redis
 import os
+import settings as s
 from JsonSocket import JsonSocket
 from time import sleep
 
-
 logger = logging.getLogger()
-
 
 class Server:
     """
@@ -29,7 +28,8 @@ class Server:
         self._continue = True
         self.running = False
         self._socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        self._socket.bind('/var/sockets/darwin/darwin.sock')
+        self._socket.bind('{}/sockets{}/darwin.sock'
+                          .format(s.prefix, s.suffix))
         self._socket.listen(5)
         self._socket.settimeout(1)
 
@@ -38,7 +38,7 @@ class Server:
         Close the socket.
         """
         self._socket.close()
-        os.unlink('/var/sockets/darwin/darwin.sock')
+        os.unlink('{}/sockets{}/darwin.sock'.format(s.prefix, s.suffix))
 
     def process(self, services, cli, cmd):
         """

--- a/manager/Administration.py
+++ b/manager/Administration.py
@@ -10,7 +10,7 @@ import socket
 import logging
 import redis
 import os
-import settings as s
+import settings
 from JsonSocket import JsonSocket
 from time import sleep
 
@@ -29,7 +29,7 @@ class Server:
         self.running = False
         self._socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self._socket.bind('{}/sockets{}/darwin.sock'
-                          .format(s.prefix, s.suffix))
+                          .format(prefix, suffix))
         self._socket.listen(5)
         self._socket.settimeout(1)
 
@@ -38,7 +38,7 @@ class Server:
         Close the socket.
         """
         self._socket.close()
-        os.unlink('{}/sockets{}/darwin.sock'.format(s.prefix, s.suffix))
+        os.unlink('{}/sockets{}/darwin.sock'.format(prefix, suffix))
 
     def process(self, services, cli, cmd):
         """

--- a/manager/Services.py
+++ b/manager/Services.py
@@ -20,6 +20,7 @@ from HeartBeat import HeartBeat
 from time import sleep
 import psutil
 from config import load_conf, ConfParseError
+import settings as s
 
 logger = logging.getLogger()
 
@@ -370,15 +371,18 @@ class Services:
                 except KeyError:
                     new[n]['failures'] = 0
 
-                new[n]['pid_file'] = '/var/run/darwin/{name}{extension}.pid'.format(
+                new[n]['pid_file'] = '{prefix}/run{suffix}/{name}{extension}.pid'.format(
+                    prefix=s.prefix, suffix=s.suffix,
                     name=n, extension=new[n]['extension']
                 )
 
-                new[n]['socket'] = '/var/sockets/darwin/{name}{extension}.sock'.format(
+                new[n]['socket'] = '{prefix}/sockets{suffix}/{name}{extension}.sock'.format(
+                    prefix=s.prefix, suffix=s.suffix,
                     name=n, extension=new[n]['extension']
                 )
 
-                new[n]['monitoring'] = '/var/sockets/darwin/{name}_mon{extension}.sock'.format(
+                new[n]['monitoring'] = '{prefix}/sockets{suffix}/darwin/{name}_mon{extension}.sock'.format(
+                    prefix=s.prefix, suffix=s.suffix,
                     name=n, extension=new[n]['extension']
                 )
 

--- a/manager/Services.py
+++ b/manager/Services.py
@@ -9,6 +9,7 @@ __doc__ = 'Services / filters management'
 import logging
 import json
 import socket
+import settings
 from threading import Lock
 from copy import deepcopy
 from subprocess import Popen, call, TimeoutExpired
@@ -20,7 +21,6 @@ from HeartBeat import HeartBeat
 from time import sleep
 import psutil
 from config import load_conf, ConfParseError
-import settings as s
 
 logger = logging.getLogger()
 
@@ -372,17 +372,17 @@ class Services:
                     new[n]['failures'] = 0
 
                 new[n]['pid_file'] = '{prefix}/run{suffix}/{name}{extension}.pid'.format(
-                    prefix=s.prefix, suffix=s.suffix,
+                    prefix=prefix, suffix=suffix,
                     name=n, extension=new[n]['extension']
                 )
 
                 new[n]['socket'] = '{prefix}/sockets{suffix}/{name}{extension}.sock'.format(
-                    prefix=s.prefix, suffix=s.suffix,
+                    prefix=prefix, suffix=suffix,
                     name=n, extension=new[n]['extension']
                 )
 
                 new[n]['monitoring'] = '{prefix}/sockets{suffix}/{name}_mon{extension}.sock'.format(
-                    prefix=s.prefix, suffix=s.suffix,
+                    prefix=prefix, suffix=suffix,
                     name=n, extension=new[n]['extension']
                 )
 

--- a/manager/Services.py
+++ b/manager/Services.py
@@ -381,7 +381,7 @@ class Services:
                     name=n, extension=new[n]['extension']
                 )
 
-                new[n]['monitoring'] = '{prefix}/sockets{suffix}/darwin/{name}_mon{extension}.sock'.format(
+                new[n]['monitoring'] = '{prefix}/sockets{suffix}/{name}_mon{extension}.sock'.format(
                     prefix=s.prefix, suffix=s.suffix,
                     name=n, extension=new[n]['extension']
                 )

--- a/manager/config.py
+++ b/manager/config.py
@@ -10,6 +10,8 @@ import logging
 import json
 from jsonschema import validators, Draft7Validator
 import psutil
+import settings as s
+
 
 logger = logging.getLogger()
 
@@ -266,18 +268,20 @@ def complete_filters_conf():
         filter['status'] = psutil.STATUS_WAKING
         filter['failures'] = 0
         filter['extension'] = '.1'
-        filter['pid_file'] = '/var/run/darwin/{filter}{extension}.pid'.format(filter=filter['name'], extension=filter['extension'])
+        filter['pid_file'] = '{prefix}/run{suffix}/{filter}{extension}.pid'.format(prefix=s.prefix, suffix=s.suffix, filter=filter['name'], extension=filter['extension'])
 
         if not filter['next_filter']:
             filter['next_filter_unix_socket'] = 'no'
         else:
-            filter['next_filter_unix_socket'] = '/var/sockets/darwin/{next_filter}.sock'.format(
+            filter['next_filter_unix_socket'] = '{prefix}/sockets{suffix}/{next_filter}.sock'.format(
+                prefix=s.prefix, suffix=s.suffix,
                 next_filter=filter['next_filter']
             )
 
-        filter['socket'] = '/var/sockets/darwin/{filter}{extension}.sock'.format(filter=filter['name'], extension=filter['extension'])
-        filter['socket_link'] = '/var/sockets/darwin/{filter}.sock'.format(filter=filter['name'])
+        filter['socket'] = '{prefix}/sockets{suffix}/{filter}{extension}.sock'.format(prefix=s.prefix, suffix=s.suffix, filter=filter['name'], extension=filter['extension'])
+        filter['socket_link'] = '{prefix}/sockets{suffix}/{filter}.sock'.format(prefix=s.prefix, suffix=s.suffix, filter=filter['name'])
 
-        filter['monitoring'] = '/var/sockets/darwin/{filter}_mon{extension}.sock'.format(
+        filter['monitoring'] = '{prefix}/sockets{suffix}/{filter}_mon{extension}.sock'.format(
+            prefix=s.prefix, suffix=s.suffix,
             filter=filter['name'], extension=filter['extension']
         )

--- a/manager/config.py
+++ b/manager/config.py
@@ -10,7 +10,7 @@ import logging
 import json
 from jsonschema import validators, Draft7Validator
 import psutil
-import settings as s
+import settings
 
 
 logger = logging.getLogger()
@@ -268,20 +268,20 @@ def complete_filters_conf():
         filter['status'] = psutil.STATUS_WAKING
         filter['failures'] = 0
         filter['extension'] = '.1'
-        filter['pid_file'] = '{prefix}/run{suffix}/{filter}{extension}.pid'.format(prefix=s.prefix, suffix=s.suffix, filter=filter['name'], extension=filter['extension'])
+        filter['pid_file'] = '{prefix}/run{suffix}/{filter}{extension}.pid'.format(prefix=prefix, suffix=suffix, filter=filter['name'], extension=filter['extension'])
 
         if not filter['next_filter']:
             filter['next_filter_unix_socket'] = 'no'
         else:
             filter['next_filter_unix_socket'] = '{prefix}/sockets{suffix}/{next_filter}.sock'.format(
-                prefix=s.prefix, suffix=s.suffix,
+                prefix=prefix, suffix=suffix,
                 next_filter=filter['next_filter']
             )
 
-        filter['socket'] = '{prefix}/sockets{suffix}/{filter}{extension}.sock'.format(prefix=s.prefix, suffix=s.suffix, filter=filter['name'], extension=filter['extension'])
-        filter['socket_link'] = '{prefix}/sockets{suffix}/{filter}.sock'.format(prefix=s.prefix, suffix=s.suffix, filter=filter['name'])
+        filter['socket'] = '{prefix}/sockets{suffix}/{filter}{extension}.sock'.format(prefix=prefix, suffix=suffix, filter=filter['name'], extension=filter['extension'])
+        filter['socket_link'] = '{prefix}/sockets{suffix}/{filter}.sock'.format(prefix=prefix, suffix=suffix, filter=filter['name'])
 
         filter['monitoring'] = '{prefix}/sockets{suffix}/{filter}_mon{extension}.sock'.format(
-            prefix=s.prefix, suffix=s.suffix,
+            prefix=prefix, suffix=suffix,
             filter=filter['name'], extension=filter['extension']
         )

--- a/manager/manager.py
+++ b/manager/manager.py
@@ -12,7 +12,7 @@ import argparse
 import signal
 import atexit
 import os
-import settings as s
+import settings
 from sys import exit
 from daemon import DaemonContext
 from lockfile import FileLock
@@ -45,13 +45,13 @@ parser.add_argument('-l', '--log-level',
                     choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
                     type=str)
 parser.add_argument('-p', '--prefix-directories',
-                    help='Set the prefix used for darwin files, default : \"var\"',
+                    help='Set the prefix used for darwin files, default : \"/var\"',
                     default='var',
                     type=str)
 
 suffix_exclusive = parser.add_mutually_exclusive_group()
 suffix_exclusive.add_argument('-s', '--suffix-directories',
-                    help='Set the suffix used for darwin files, default : \"darwin\"',
+                    help='Set the suffix used for darwin files, default : \"/darwin\"',
                     default='darwin',
                     type=str)
 suffix_exclusive.add_argument('--no-suffix-directories',
@@ -60,13 +60,13 @@ suffix_exclusive.add_argument('--no-suffix-directories',
 
 args = parser.parse_args()
 
-s.prefix = '/{}'.format(args.prefix_directories)
+prefix = '{}'.format(args.prefix_directories)
 if args.no_suffix_directories:
-    s.suffix = ''
+    suffix = ''
 else:
-    s.suffix = '/{}'.format(args.suffix_directories)
+    suffix = '{}'.format(args.suffix_directories)
 
-make_setup(['log', 'run', 'sockets'], s.prefix, s.suffix)
+make_setup(['log', 'run', 'sockets'], prefix, suffix)
 
 # Logger config
 loglevel = logging.WARNING
@@ -86,7 +86,7 @@ formatter = logging.Formatter(
     '{"date":"%(asctime)s","level":"%(levelname)s","message":"%(message)s"}')
 
 # Create log file if doesn't exist
-log_path = '{}/log{}/darwin_manager.log'.format(s.prefix, s.suffix)
+log_path = '{}/log{}/darwin_manager.log'.format(prefix, suffix)
 if not os.path.isfile(log_path):
     open(log_path, "a+").close()
 
@@ -124,7 +124,7 @@ if __name__ == '__main__':
     signal.signal(signal.SIGHUP, rotate_logs)
 
     logger.info("Starting...")
-    daemon_context = DaemonContext(pidfile=FileLock('{}/run{}/manager.pid'.format(s.suffix, s.prefix)),)
+    daemon_context = DaemonContext(pidfile=FileLock('{}/run{}/manager.pid'.format(suffix, prefix)),)
     daemon_context.detach_process = False
     logger.debug("daemon DONE")
 

--- a/manager/manager.py
+++ b/manager/manager.py
@@ -11,6 +11,8 @@ import logging
 import argparse
 import signal
 import atexit
+import os
+import settings as s
 from sys import exit
 from daemon import DaemonContext
 from lockfile import FileLock
@@ -23,6 +25,18 @@ from config import load_conf, ConfParseError
 from config import filters as conf_filters
 from config import stats_reporting as conf_stats_report
 
+def make_setup(dirs, prefix, suffix):
+    """
+        Create directories if it doesn't exist
+        :param dirs: name of the directories to be created
+        :param prefix: directory's path preffix
+        :param suffix : directory's path suffix
+    """
+    for d in dirs:
+        path = '{}/{}{}'.format(prefix, d, suffix)
+        if not os.path.exists(path):
+            os.mkdir(path)
+
 # Argparse
 parser = argparse.ArgumentParser()
 parser.add_argument('config_file', type=str, help='The configuration file to use')
@@ -30,7 +44,29 @@ parser.add_argument('-l', '--log-level',
                     help='Set log level to DEBUG, INFO, WARNING (default), ERROR or CRITICAL',
                     choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
                     type=str)
+parser.add_argument('-p', '--prefix-directories',
+                    help='Set the prefix used for darwin files, default : \"var\"',
+                    default='var',
+                    type=str)
+
+suffix_exclusive = parser.add_mutually_exclusive_group()
+suffix_exclusive.add_argument('-s', '--suffix-directories',
+                    help='Set the suffix used for darwin files, default : \"darwin\"',
+                    default='darwin',
+                    type=str)
+suffix_exclusive.add_argument('--no-suffix-directories',
+                    help='Use no suffix for darwin files',
+                    action='store_true')
+
 args = parser.parse_args()
+
+s.prefix = '/{}'.format(args.prefix_directories)
+if args.no_suffix_directories:
+    s.suffix = ''
+else:
+    s.suffix = '/{}'.format(args.suffix_directories)
+
+make_setup(['log', 'run', 'sockets'], s.prefix, s.suffix)
 
 # Logger config
 loglevel = logging.WARNING
@@ -49,7 +85,12 @@ logger.setLevel(loglevel)
 formatter = logging.Formatter(
     '{"date":"%(asctime)s","level":"%(levelname)s","message":"%(message)s"}')
 
-file_handler = FileHandler('/var/log/darwin/darwin_manager.log')
+# Create log file if doesn't exist
+log_path = '{}/log{}/darwin_manager.log'.format(s.prefix, s.suffix)
+if not os.path.isfile(log_path):
+    open(log_path, "a+").close()
+
+file_handler = FileHandler(log_path, mode="a+")
 
 file_handler.setLevel(loglevel)
 file_handler.setFormatter(formatter)
@@ -83,7 +124,7 @@ if __name__ == '__main__':
     signal.signal(signal.SIGHUP, rotate_logs)
 
     logger.info("Starting...")
-    daemon_context = DaemonContext(pidfile=FileLock('/var/run/darwin/manager.pid'),)
+    daemon_context = DaemonContext(pidfile=FileLock('{}/run{}/manager.pid'.format(s.suffix, s.prefix)),)
     daemon_context.detach_process = False
     logger.debug("daemon DONE")
 

--- a/manager/settings.py
+++ b/manager/settings.py
@@ -1,0 +1,2 @@
+prefix = '/var'
+suffix = '/darwin'

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -1,6 +1,6 @@
-MANAGEMENT_SOCKET_PATH = '/var/sockets/darwin/darwin.sock'
-FILTER_SOCKETS_DIR = "/var/sockets/darwin/"
-FILTER_PIDS_DIR = "/var/run/darwin/"
+MANAGEMENT_SOCKET_PATH = '/tmp/sockets/darwin.sock'
+FILTER_SOCKETS_DIR = '/tmp/sockets/'
+FILTER_PIDS_DIR = '/tmp/run/'
 DEFAULT_CONFIGURATION_PATH = '/tmp/darwin.conf'
 DEFAULT_MANAGER_PATH = '/home/darwin/manager/manager.py'
 DEFAULT_FILTER_PATH = '/home/darwin/filters/'

--- a/tests/tools/darwin_utils.py
+++ b/tests/tools/darwin_utils.py
@@ -10,8 +10,12 @@ def darwin_start(darwin_manager_path=DEFAULT_MANAGER_PATH, config_path=DEFAULT_C
         darwin_manager_path,
         '-l',
         'DEBUG',
+        '-p',
+        'tmp',
+        '--no-suffix-directories',
         config_path
     ])
+
     sleep(3)
     return process
 


### PR DESCRIPTION
# :sparkles: Pull Request Template
:bangbang: Once all the **checklist** is **done** you have to:
  * **stash merge** this pull request
  * **delete** the corresponding **branch**
  * **close** the associated **issue**

## :page_with_curl: Type of change

**Breaking change**: fix or feature that would cause existing functionality to not work as expected.

## :bulb: Related Issue(s)

- Resolve #126 

## :black_nib: Description

Now we can set a prefix and a suffix for darwin path, e.g for the log files, if your prefix is 'tmp' and your suffix 'darwin' they will be found in /tmp/logs/darwin ([prefix]/logs[suffix])

They can be set from the manager options :
usage: manager.py [-h] [-l {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
                  [-p PREFIX_DIRECTORIES]
                  [-s SUFFIX_DIRECTORIES | --no-suffix-directories]
                  config_file

By default the prefix is '/var' and the suffix '/darwin'. Like said in the usage, you can't remove the default prefix, but you can remove the default suffix with the '--no-suffix-directories' options.

## :dart: Test Environments

### FreeBSD 12.0
- clang++  6.0.1
- CMake 3.7.2
- Python 3

### Ubuntu 19.0.4
- g++ 8.3.0
- CMake 3.7.2
- Python 3

## :heavy_check_mark: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes

</br>

- [x] :raising_hand: **I certify on my honor that all the information provided is true, and I've done all I can to deliver a high quality code**
