### PR TITLE
STATS:: REMOVE REGRESSION IN STATS/MONITORING REPORTS' FORMAT

### DIFF
--- a/manager/Administration.py
+++ b/manager/Administration.py
@@ -12,6 +12,7 @@ import redis
 import os
 from JsonSocket import JsonSocket
 from time import sleep
+import json
 
 
 logger = logging.getLogger()
@@ -176,7 +177,7 @@ class Server:
                 if not self._continue:
                     logger.debug("Reporter: stopping")
                     break
-                stats = services.monitor_all()
+                stats = json.dumps(services.monitor_all())
                 logger.debug("reporting stats: {}".format(stats))
 
                 if self._stats_redis:
@@ -185,10 +186,10 @@ class Server:
                         redis_list = self._stats['redis'].get('list', None)
                         if redis_pub:
                             logger.debug("Reporting stats on Redis channel {}".format(redis_pub))
-                            self._stats_redis.publish(redis_pub, stats)
+                            self._stats_redis.publish(redis_pub, stats.encode("ascii"))
                         if redis_list:
                             logger.debug("Reporting stats on Redis list {}".format(redis_list))
-                            self._stats_redis.rpush(redis_list, stats)
+                            self._stats_redis.rpush(redis_list, stats.encode("ascii"))
                     except redis.exceptions.ConnectionError as e:
                         logger.error("Could not report stats to Redis: {}".format(e))
 

--- a/manager/Services.py
+++ b/manager/Services.py
@@ -504,7 +504,7 @@ class Services:
                 else:
                     monitor_data[n] = {}
                     monitor_data[n]['status'] = 'error'
-        return json.dumps(monitor_data)
+        return monitor_data
 
     @staticmethod
     def _wait_process_ready(content):

--- a/tests/manager_socket/reporting_test.py
+++ b/tests/manager_socket/reporting_test.py
@@ -65,7 +65,6 @@ def proc_stats_default():
 
     try:
         resp = json.loads(requests(REQ_MONITOR))
-        resp = json.loads(resp)
 
         try:
             result = resp['logs_1']['proc_stats']
@@ -95,7 +94,6 @@ def proc_stats_other_defaults():
 
     try:
         resp = json.loads(requests(REQ_MONITOR))
-        resp = json.loads(resp)
 
         try:
             result = resp['logs_1']['proc_stats']
@@ -125,7 +123,6 @@ def proc_stats_custom():
 
     try:
         resp = json.loads(requests(REQ_MONITOR_CUSTOM_STATS))
-        resp = json.loads(resp)
 
         try:
             result = resp['logs_1']['proc_stats']
@@ -154,7 +151,6 @@ def proc_stats_wrong():
 
     try:
         resp = json.loads(requests(REQ_MONITOR_ERROR))
-        resp = json.loads(resp)
 
         try:
             result = resp['logs_1']['proc_stats']

--- a/tests/manager_socket/utils.py
+++ b/tests/manager_socket/utils.py
@@ -290,9 +290,9 @@ REQ_UPDATE_NO_FILTER = b'{"type": "update_filters"}'
 
 RESP_EMPTY     = '{}'
 
-RESP_LOGS_1 = '\\"logs_1\\": {\\"status\\": \\"running\\", \\"connections\\": 0, \\"received\\": 0, \\"entryErrors\\": 0, \\"matches\\": 0, \\"failures\\": 0, \\"proc_stats\\": {'
-RESP_LOGS_2 = '\\"logs_2\\": {\\"status\\": \\"running\\", \\"connections\\": 0, \\"received\\": 0, \\"entryErrors\\": 0, \\"matches\\": 0, \\"failures\\": 0, \\"proc_stats\\": {'
-RESP_LOGS_3 = '\\"logs_3\\": {\\"status\\": \\"running\\", \\"connections\\": 0, \\"received\\": 0, \\"entryErrors\\": 0, \\"matches\\": 0, \\"failures\\": 0, \\"proc_stats\\": {'
+RESP_LOGS_1 = '"logs_1": {"status": "running", "connections": 0, "received": 0, "entryErrors": 0, "matches": 0, "failures": 0, "proc_stats": {'
+RESP_LOGS_2 = '"logs_2": {"status": "running", "connections": 0, "received": 0, "entryErrors": 0, "matches": 0, "failures": 0, "proc_stats": {'
+RESP_LOGS_3 = '"logs_3": {"status": "running", "connections": 0, "received": 0, "entryErrors": 0, "matches": 0, "failures": 0, "proc_stats": {'
 RESP_STATUS_OK = '"status": "OK"'
 RESP_STATUS_KO = '"status": "KO"'
 RESP_ERROR_NO_PID = '"error": "PID file not accessible"'


### PR DESCRIPTION
# HOTFIX 1.2.1

## Manager
Fix double encoding of the JSON response of the `{"type": "monitor"}` command.

1.1 and before -> JSON
1.2 -> String containing a JSON
1.2.1 -> JSON