### PR TITLE
ADD HOSTLOOKUP DB BACKWARD COMPATIBILITY

### DIFF
--- a/samples/fhostlookup/Generator.cpp
+++ b/samples/fhostlookup/Generator.cpp
@@ -21,9 +21,10 @@
 bool Generator::LoadConfig(const rapidjson::Document &configuration) {
     DARWIN_LOGGER;
     DARWIN_LOG_DEBUG("HostLookup:: Generator:: Loading classifier...");
-    std::string  db;
-    rapidjson::Document database;
+    std::string db;
+    std::string db_type;
 
+    // Load DB Name
     if (!configuration.HasMember("database")) {
         DARWIN_LOG_CRITICAL("HostLookup:: Generator:: Missing parameter: 'database'");
         return false;
@@ -33,16 +34,72 @@ bool Generator::LoadConfig(const rapidjson::Document &configuration) {
         return false;
     }
     db = configuration["database"].GetString();
-    std::ifstream file(db.c_str());
+
+    // Load DB Type
+    if (configuration.HasMember("db_type")) {
+            if (!configuration["db_type"].IsString()) {
+            DARWIN_LOG_CRITICAL("HostLookup:: Generator:: 'db_type' needs to be a string");
+            return false;
+        }
+        db_type = configuration["db_type"].GetString();
+    } else {
+        db_type = "text";
+    }
+
+    // Load the DB according to the given type
+    if (db_type == "json") {
+        return this->LoadJsonFile(db);
+    } else if (db_type == "text") {
+        return this->LoadTextFile(db);
+    } else {
+        DARWIN_LOG_CRITICAL("HostLookup:: Generator:: Unknown 'db_type'");
+        return false;
+    }
+    return false; // Put it there just in case.
+}
+
+bool Generator::LoadTextFile(const std::string& filename) {
+    DARWIN_LOGGER;
+    std::ifstream file(filename.c_str());
+    std::string buf;
+
+    // Load file content
     if (!file) {
         DARWIN_LOG_CRITICAL("HostLookup:: Generator:: Configure:: Cannot open host database");
         return false;
     }
+    while (!darwin::files_utils::GetLineSafe(file, buf).eof()) {
+        if(file.fail() or file.bad()){
+            DARWIN_LOG_CRITICAL("HostLookup:: Generator:: Configure:: Error when reading host database");
+            return false;
+        }
+        if (!buf.empty()){
+            _database.insert({buf,100});
+        }
+    }
+    file.close();
 
+    // Get feed namme from file name
+    buf = darwin::files_utils::GetNameFromPath(filename); // Filename already proven valid
+    darwin::files_utils::ReplaceExtension(buf, "");
+    this->_feed_name = buf;
+
+    return true;
+}
+
+bool Generator::LoadJsonFile(const std::string& filename) {
+    DARWIN_LOGGER;
+    std::ifstream file(filename.c_str());
+    rapidjson::Document database;
+
+    if (!file) {
+        DARWIN_LOG_CRITICAL("HostLookup:: Generator:: Configure:: Cannot open host database");
+        return false;
+    }
     DARWIN_LOG_DEBUG("HostlookupGenerator:: Parsing database...");
     rapidjson::IStreamWrapper isw(file);
     database.ParseStream(isw);
-    if (not this->LoadDatabase(database)) {
+    if (not this->LoadJsonDatabase(database)) {
         file.close();
         return false;
     }
@@ -50,7 +107,7 @@ bool Generator::LoadConfig(const rapidjson::Document &configuration) {
     return true;
 }
 
-bool Generator::LoadDatabase(const rapidjson::Document& database) {
+bool Generator::LoadJsonDatabase(const rapidjson::Document& database) {
     DARWIN_LOGGER;
     if (not database.IsObject()) {
         DARWIN_LOG_CRITICAL("HostlookupGenerator:: Database is not a JSON object");
@@ -71,7 +128,7 @@ bool Generator::LoadDatabase(const rapidjson::Document& database) {
         return false;
     }
     for (auto& entry : entries) {
-        this->LoadEntry(entry);
+        this->LoadJsonEntry(entry);
     }
     if (this->_database.size() == 0) {
         DARWIN_LOG_CRITICAL("HostlookupGenerator:: No usable entry in the database. Stopping.");
@@ -80,7 +137,7 @@ bool Generator::LoadDatabase(const rapidjson::Document& database) {
     return true;
 }
 
-bool Generator::LoadEntry(const rapidjson::Value& entry) {
+bool Generator::LoadJsonEntry(const rapidjson::Value& entry) {
     DARWIN_LOGGER;
     int score = 100;
     std::string sentry;

--- a/samples/fhostlookup/Generator.cpp
+++ b/samples/fhostlookup/Generator.cpp
@@ -79,7 +79,7 @@ bool Generator::LoadTextFile(const std::string& filename) {
     }
     file.close();
 
-    // Get feed namme from file name
+    // Get feed name from file name
     buf = darwin::files_utils::GetNameFromPath(filename); // Filename already proven valid
     darwin::files_utils::ReplaceExtension(buf, "");
     this->_feed_name = buf;

--- a/samples/fhostlookup/Generator.hpp
+++ b/samples/fhostlookup/Generator.hpp
@@ -30,8 +30,10 @@ public:
 
 protected:
     virtual bool LoadConfig(const rapidjson::Document &configuration) override final;
-    bool LoadDatabase(const rapidjson::Document& database);
-    bool LoadEntry(const rapidjson::Value& entry);
+    bool LoadTextFile(const std::string& filename);
+    bool LoadJsonFile(const std::string& filename);
+    bool LoadJsonDatabase(const rapidjson::Document& database);
+    bool LoadJsonEntry(const rapidjson::Value& entry);
 
 private:
     // This implementation is thread safe with multiple reader

--- a/samples/fhostlookup/HostLookupTask.cpp
+++ b/samples/fhostlookup/HostLookupTask.cpp
@@ -25,7 +25,7 @@ HostLookupTask::HostLookupTask(boost::asio::local::stream_protocol::socket& sock
                                std::mutex& cache_mutex,
                                tsl::hopscotch_map<std::string, int>& db,
                                const std::string& feed_name)
-        : Session{"host_lookup", socket, manager, cache, cache_mutex}, _database{db},
+        : Session{"hostlookup", socket, manager, cache, cache_mutex}, _database{db},
         _feed_name{feed_name} {
     _is_cache = _cache != nullptr;
 }
@@ -61,6 +61,7 @@ void HostLookupTask::operator()() {
                         std::string alert_log = this->BuildAlert(_host, certitude);
                         DARWIN_RAISE_ALERT(alert_log);
                         if (is_log) {
+                            _logs += alert_log + "\n";
                         }
                     }
                     _certitudes.push_back(certitude);
@@ -74,6 +75,7 @@ void HostLookupTask::operator()() {
             if (certitude >= _threshold and certitude < DARWIN_ERROR_RETURN) {
                 STAT_MATCH_INC;
                 std::string alert_log = this->BuildAlert(_host, certitude);
+                DARWIN_RAISE_ALERT(alert_log);
                 if (is_log){
                     _logs += alert_log + "\n";
                 }

--- a/toolkit/Files.cpp
+++ b/toolkit/Files.cpp
@@ -41,6 +41,31 @@ namespace darwin {
             }
         }
 
+        std::string GetNameFromPath(const std::string& filename) {
+            char sep = '/';
+
+        #ifdef _WIN32
+            sep = '\\';
+        #endif
+
+            size_t i = filename.rfind(sep, filename.length());
+            if (i != std::string::npos) {
+                return(filename.substr(i+1, filename.length() - i));
+            }
+
+            return("");
+        }
+
+        void ReplaceExtension(std::string& filename, const std::string& new_extension) {
+            std::string::size_type i = filename.rfind('.', filename.length());
+
+            if (i != std::string::npos) {
+                if (new_extension.empty())
+                    filename = filename.substr(0, i);
+                else
+                    filename.replace(i+1, new_extension.length(), new_extension);
+            }
+        }
 
     }
 }

--- a/toolkit/Files.hpp
+++ b/toolkit/Files.hpp
@@ -15,5 +15,18 @@ namespace darwin {
     /// \namespace validator
     namespace files_utils {
         std::istream& GetLineSafe(std::istream& is, std::string& t);
+
+        /// Extract the file name from the complete file path
+        ///
+        /// \param filename A string containing the complete file path
+        /// \return A string contaning the extracted file name. Empty not found.
+        std::string GetNameFromPath(const std::string& filename);
+
+        /// Replace the file extension.
+        /// If no extension found no action performed.
+        ///
+        /// \param filename The original filename. This agrument is modified.
+        /// \param new_extension The new extension to applys to the filename
+        void ReplaceExtension(std::string& filename, const std::string& new_extension);
     }
 }


### PR DESCRIPTION
# :sparkles: Pull Request Template
:bangbang: Once all the **checklist** is **done** you have to:
  * **stash merge** this pull request
  * **delete** the corresponding **branch**
  * **close** the associated **issue**

## :page_with_curl: Type of change

**Unbreaking change**: Change that restore backward compatibility over a previous breaking change

## :bulb: Related Issue(s)

_No_

## :black_nib: Description

### Hostlookup
- Added backward compatibility with the basic text db format
  - Added `db_type` optional field to configuration :
    - `text` for basic text format
    - `json` for the new JSON format
    - Default is `text`
  - Feed name is the file name without extention in `text` mode

### Tests
#### Hostlookup
- Added backward compatibility tests

### Toolkit
#### Files
- Added filename formatting utils

## :dart: Test Environments

### FreeBSD 12.1 RELEASE
- Redis 5.0.7
- Boost 1.72.0
- clang++ 8.0.1
- CMake 3.15.5
- Python 3.7.6

## :heavy_check_mark: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

</br>

- [x] :raising_hand: **I certify on my honor that all the information provided is true, and I've done all I can to deliver a high quality code**