### PR TITLE
FIX:: Generate correct ISO 8601 timestamps in UTC for alerting

### DIFF
--- a/toolkit/Time.cpp
+++ b/toolkit/Time.cpp
@@ -10,8 +10,8 @@ namespace darwin {
             std::string res;
 
             time(&rawtime);
-            timeinfo = localtime(&rawtime);
-            strftime(str_time, sizeof(str_time), "%F%Z%T%z", timeinfo);
+            timeinfo = gmtime(&rawtime);
+            strftime(str_time, sizeof(str_time), "%FT%TZ", timeinfo);
             res = str_time;
 
             return res;


### PR DESCRIPTION
# :sparkles: FIX:: Generate correct ISO 8601 timestamps in UTC for alerting
:bangbang: Once all the **checklist** is **done** you have to:
  * **stash merge** this pull request
  * **delete** the corresponding **branch**
  * **close** the associated **issue**

## :page_with_curl: Type of change

**Bug fix**: non-breaking change which fixes an issue.
**Breaking change**: fix or feature that would cause existing functionality to not work as expected.


## :bulb: Related Issue(s)

- Resolve #166 

## :black_nib: Description

Changed GetTime's toolkit function to return valid RFC3339 timestamps, used for alerts generation.
**[BREAKING CHANGE] Those timestamps are now always generated as UTC.**

## :dart: Test Environments

### HBSD (12.1)
- g++ (9.3.0)
- CMake (3.17.2)

### Ubuntu (18.04)
- g++ (or clang++) (7.5.0)
- CMake (3.10.2)
- Valgrind (3.13.0)

## :heavy_check_mark: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] (**If other changes**) I have made corresponding changes to the documentation
- [x] New and existing tests pass locally with my changes

</br>

- [x] :raising_hand: **I certify on my honor that all the information provided is true, and I've done all I can to deliver a high quality code**
