### PR TITLE
CREATING A MORE UNIFORM ALERT FORMAT

### DIFF
--- a/docker/darwin
+++ b/docker/darwin
@@ -169,7 +169,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  python3-setuptools \
  python3-wheel \
  python3-psutil \
- python3-daemon \
  python3-redis \
  && rm -rf /var/lib/apt/lists/*
 

--- a/manager/Administration.py
+++ b/manager/Administration.py
@@ -10,7 +10,6 @@ import socket
 import logging
 import redis
 import os
-import settings
 from JsonSocket import JsonSocket
 from time import sleep
 import json

--- a/manager/Administration.py
+++ b/manager/Administration.py
@@ -22,15 +22,17 @@ class Server:
     Manages administration connections for filter update and monitoring.
     """
 
-    def __init__(self):
+    def __init__(self, prefix, suffix):
         """
         Constructor. Create the UNIX socket to listen on.
         """
         self._continue = True
         self.running = False
+        self._prefix = prefix
+        self._suffix = suffix
+        self._socket_path = '{}/sockets{}/darwin.sock'.format(prefix, suffix)
         self._socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        self._socket.bind('{}/sockets{}/darwin.sock'
-                          .format(prefix, suffix))
+        self._socket.bind(self._socket_path)
         self._socket.listen(5)
         self._socket.settimeout(1)
 
@@ -39,7 +41,7 @@ class Server:
         Close the socket.
         """
         self._socket.close()
-        os.unlink('{}/sockets{}/darwin.sock'.format(prefix, suffix))
+        os.unlink(self._socket_path)
 
     def process(self, services, cli, cmd):
         """
@@ -52,7 +54,7 @@ class Server:
         response = {}
         if cmd.get('type', None):
             if cmd['type'] == 'update_filters':
-                errors = services.update(cmd.get('filters', []))
+                errors = services.update(cmd.get('filters', []), self._prefix, self._suffix)
                 errors += self.update_stats_conf()
                 if not errors:
                     response['status'] = 'OK'

--- a/manager/Services.py
+++ b/manager/Services.py
@@ -9,7 +9,6 @@ __doc__ = 'Services / filters management'
 import logging
 import json
 import socket
-import settings
 from threading import Lock
 from copy import deepcopy
 from subprocess import Popen, call, TimeoutExpired

--- a/manager/Services.py
+++ b/manager/Services.py
@@ -52,6 +52,7 @@ class Services:
                         self.stop_one(filter, no_lock=True)
                         self.clean_one(filter, no_lock=True)
                     else:
+                        logger.debug("Linking UNIX sockets...")
                         filter['status'] = psutil.STATUS_RUNNING
                         call(['ln', '-s', filter['socket'], filter['socket_link']])
 
@@ -70,11 +71,15 @@ class Services:
         """
         Stop all the filters
         """
+        logger.debug("stop_all: before lock")
         with self._lock:
+            logger.debug("stop_all: after lock")
             for _, filter in self._filters.items():
                 try:
                     self.stop_one(filter, True)
+                    logger.debug("stop_all: after stop_one")
                     self.clean_one(filter, True)
+                    logger.debug("stop_all: after clean_one")
                 except Exception:
                     pass
 
@@ -316,7 +321,7 @@ class Services:
             filter['status'] = psutil.STATUS_RUNNING
             call(['ln', '-s', filter['socket'], filter['socket_link']])
 
-    def update(self, names):
+    def update(self, names, prefix, suffix):
         """
         Update the filters which name are contained in names
         configuration and process.
@@ -328,7 +333,7 @@ class Services:
         logger.debug("Update: Trying to open config file")
         try:
             #Reload conf, global variable 'conf_filters' will be updated
-            load_conf()
+            load_conf(prefix, suffix)
         except ConfParseError:
             error = "Update: wrong configuration format, unable to update"
             logger.error(error)

--- a/manager/config.py
+++ b/manager/config.py
@@ -10,7 +10,6 @@ import logging
 import json
 from jsonschema import validators, Draft7Validator
 import psutil
-import settings
 
 
 logger = logging.getLogger()

--- a/manager/config.py
+++ b/manager/config.py
@@ -219,7 +219,7 @@ class ConfParseError(Exception):
     pass
 
 
-def load_conf(conf=""):
+def load_conf(prefix, suffix, conf=""):
     global config_file
     global stats_reporting
     global filters
@@ -259,9 +259,9 @@ def load_conf(conf=""):
         filters.update(configuration)
         logger.debug("Configurator: loaded v1 config successfully")
 
-    complete_filters_conf()
+    complete_filters_conf(prefix, suffix)
 
-def complete_filters_conf():
+def complete_filters_conf(prefix, suffix):
     for name, filter in filters.items():
         if name and not filter.get('name'):
             filter['name'] = name

--- a/manager/manager.py
+++ b/manager/manager.py
@@ -12,10 +12,7 @@ import argparse
 import signal
 import atexit
 import os
-import settings
 from sys import exit
-from daemon import DaemonContext
-from lockfile import FileLock
 from Services import Services
 from logging import FileHandler
 from Administration import Server
@@ -25,7 +22,7 @@ from config import load_conf, ConfParseError
 from config import filters as conf_filters
 from config import stats_reporting as conf_stats_report
 
-def make_setup(dirs, prefix, suffix):
+def create_dirs(dirs, prefix, suffix):
     """
         Create directories if they don't exist
         :param dirs: name of the directories to be created
@@ -66,7 +63,9 @@ if args.no_suffix_directories:
 else:
     suffix = '{}'.format(args.suffix_directories)
 
-make_setup(['log', 'run', 'sockets'], prefix, suffix)
+prefix = "/" + prefix.strip("/")
+suffix = "/" + suffix.strip("/")
+create_dirs(['log', 'run', 'sockets'], prefix, suffix)
 
 # Logger config
 loglevel = logging.WARNING
@@ -126,9 +125,8 @@ if __name__ == '__main__':
     signal.signal(signal.SIGHUP, rotate_logs)
 
     logger.info("Starting...")
-    daemon_context = DaemonContext(pidfile=FileLock('{}/run{}/manager.pid'.format(suffix, prefix)),)
-    daemon_context.detach_process = False
-    logger.debug("daemon DONE")
+    logger.info("prefix path is '{}'".format(prefix))
+    logger.info("suffix path is '{}'".format(suffix))
 
     server = Server(prefix, suffix)
     logger.info("Configuring...")

--- a/manager/manager.py
+++ b/manager/manager.py
@@ -100,8 +100,10 @@ logger.addHandler(file_handler)
 def sig_hdlr(sigin, frame):
     logger.info("Caught signal {}: exiting...".format(sigin))
     if server and server.running:
+        logger.debug("Stop Server")
         server.stop()
     elif services:
+        logger.debug("Stop Services")
         services.stop_all()
         exit(0)
     else:
@@ -128,10 +130,10 @@ if __name__ == '__main__':
     daemon_context.detach_process = False
     logger.debug("daemon DONE")
 
-    server = Server()
+    server = Server(prefix, suffix)
     logger.info("Configuring...")
     try:
-        load_conf(args.config_file)
+        load_conf(prefix, suffix, args.config_file)
     except ConfParseError as e:
         logger.critical(e)
         exit(1)

--- a/manager/requirements.txt
+++ b/manager/requirements.txt
@@ -1,4 +1,3 @@
 jsonschema==3.2.0
 psutil==5.6.6
-python-daemon==2.2.4
 redis==3.3.11

--- a/manager/settings.py
+++ b/manager/settings.py
@@ -1,2 +1,0 @@
-prefix = '/var'
-suffix = '/darwin'

--- a/samples/base/AGenerator.cpp
+++ b/samples/base/AGenerator.cpp
@@ -28,6 +28,39 @@ bool AGenerator::Configure(std::string const& configFile, const std::size_t cach
     return true;
 }
 
+bool AGenerator::ExtractCustomAlertingTags(const rapidjson::Document &configuration,
+                                           std::string& tags) {
+    DARWIN_LOGGER;
+
+    if (not configuration.HasMember("alert_tags")) {
+        DARWIN_LOG_DEBUG("AGenerator:: No alert_tags found in configuration");
+        return false;
+    }
+    if (not configuration["alert_tags"].IsArray()) {
+        DARWIN_LOG_WARNING("AGenerator:: Given alert_tags is not an array. Using defaults.");
+        return false;
+    }
+    auto array = configuration["alert_tags"].GetArray();
+    tags = "[";
+    for (auto& tag : array) {
+        if (not tag.IsString()) {
+            DARWIN_LOG_WARNING("AGenerator:: One alert tag is not a string. Ignoring.");
+            continue;
+        }
+        if (tag.GetStringLength() < 1) {
+            DARWIN_LOG_WARNING("AGenerator:: One alert tag is an empty string. Ignoring.");
+            continue;
+        }
+        if (tags.length() > 1)
+            tags += ',';
+        tags += '"';
+        tags += tag.GetString();
+        tags += '"';
+    }
+    tags += "]";
+    return true;
+}
+
 bool AGenerator::ReadConfig(const std::string &configuration_file_path) {
     DARWIN_LOGGER;
     DARWIN_LOG_DEBUG("AGenerator:: Setting up classifier...");
@@ -35,6 +68,7 @@ bool AGenerator::ReadConfig(const std::string &configuration_file_path) {
 
     std::ifstream conf_file_stream;
     conf_file_stream.open(configuration_file_path, std::ifstream::in);
+    std::string alerting_tags;
 
     if (!conf_file_stream.is_open()) {
         DARWIN_LOG_ERROR("AGenerator:: Could not open the configuration file");
@@ -66,6 +100,13 @@ bool AGenerator::ReadConfig(const std::string &configuration_file_path) {
     if (!this->LoadConfig(configuration)) {
         conf_file_stream.close();
         return false;
+    }
+
+    // Extract custom alerting tags
+    if (this->ExtractCustomAlertingTags(configuration, alerting_tags)) {
+        if (not this->ConfigureAlterting(alerting_tags)) return false;
+    } else {
+        this->ConfigureAlterting("");
     }
 
     conf_file_stream.close();

--- a/samples/base/AGenerator.cpp
+++ b/samples/base/AGenerator.cpp
@@ -104,9 +104,9 @@ bool AGenerator::ReadConfig(const std::string &configuration_file_path) {
 
     // Extract custom alerting tags
     if (this->ExtractCustomAlertingTags(configuration, alerting_tags)) {
-        if (not this->ConfigureAlterting(alerting_tags)) return false;
+        if (not this->ConfigureAlerting(alerting_tags)) return false;
     } else {
-        this->ConfigureAlterting("");
+        this->ConfigureAlerting("");
     }
 
     conf_file_stream.close();

--- a/samples/base/AGenerator.hpp
+++ b/samples/base/AGenerator.hpp
@@ -71,7 +71,7 @@ private:
     ///
     /// \param configuration The rapidjson object containing the parsed configuration
     /// \param tags The string to receive the configured tags
-    /// \return true if custom tags were found, false otherwies
+    /// \return true if custom tags were found, false otherwise
     virtual bool ExtractCustomAlertingTags(const rapidjson::Document &configuration,
                                            std::string& tags);
 

--- a/samples/base/AGenerator.hpp
+++ b/samples/base/AGenerator.hpp
@@ -40,6 +40,13 @@ protected:
     /// \return True on success, false on failure.
     virtual bool LoadConfig(const rapidjson::Document &configuration) = 0;
 
+    /// Configure the Alerting with the informations provided by the filter.
+    /// It is used to configure the alert's filter_name, rule_name and tags.
+    ///
+    /// \param tags The custom tags set by the user. If empty, set default tags.
+    /// \return true if everything went right, false otherwise.
+    virtual bool ConfigureAlterting(const std::string& tags) = 0;
+
 // Final methods and abstract attributes
 public:
     /// Configure the generator from file and create cache.
@@ -58,6 +65,15 @@ private:
     /// \param configuration_file_path Path to the configuration path.
     /// \return True on success, false on failure.
     virtual bool ReadConfig(const std::string &configuration_file_path) final;
+
+    /// Extract the "alert_tags" optional string list from the conf and
+    /// store it in the `tags` parameter.
+    ///
+    /// \param configuration The rapidjson object containing the parsed configuration
+    /// \param tags The string the receive the configured tags
+    /// \return true if custom tags were found, false otherwies
+    virtual bool ExtractCustomAlertingTags(const rapidjson::Document &configuration,
+                                           std::string& tags);
 
 protected:
     std::shared_ptr<boost::compute::detail::lru_cache<xxh::hash64_t, unsigned int>> _cache; //!< The cache for already processed request

--- a/samples/base/AGenerator.hpp
+++ b/samples/base/AGenerator.hpp
@@ -45,7 +45,7 @@ protected:
     ///
     /// \param tags The custom tags set by the user. If empty, set default tags.
     /// \return true if everything went right, false otherwise.
-    virtual bool ConfigureAlterting(const std::string& tags) = 0;
+    virtual bool ConfigureAlerting(const std::string& tags) = 0;
 
 // Final methods and abstract attributes
 public:

--- a/samples/base/AGenerator.hpp
+++ b/samples/base/AGenerator.hpp
@@ -70,7 +70,7 @@ private:
     /// store it in the `tags` parameter.
     ///
     /// \param configuration The rapidjson object containing the parsed configuration
-    /// \param tags The string the receive the configured tags
+    /// \param tags The string to receive the configured tags
     /// \return true if custom tags were found, false otherwies
     virtual bool ExtractCustomAlertingTags(const rapidjson::Document &configuration,
                                            std::string& tags);

--- a/samples/base/AlertManager.cpp
+++ b/samples/base/AlertManager.cpp
@@ -188,15 +188,15 @@ namespace darwin {
                                         const std::string& details) const {
         std::stringstream ss;
 
-        ss << "{\"alert_type\": \"darwin\",";
-        ss << "\"alert_subtype\": \"" << this->_filter_name << "\",";
-        ss << "\"alert_time\": \"" << darwin::time_utils::GetTime() << "\",";
-        ss << "\"level\": \"high\",";
-        ss << "\"rule_name\": \"" << this->_rule_name << "\",";
-        ss << "\"tags\": " << this->_tags << ",";
-        ss << "\"entry\": \"" << entry << "\",";
-        ss << "\"score\":"  << certitude << ",";
-        ss << "\"evt_id\": \"" << evt_id << "\",";
+        ss << "{\"alert_type\": \"darwin\", ";
+        ss << "\"alert_subtype\": \"" << this->_filter_name << "\", ";
+        ss << "\"alert_time\": \"" << darwin::time_utils::GetTime() << "\", ";
+        ss << "\"level\": \"high\", ";
+        ss << "\"rule_name\": \"" << this->_rule_name << "\", ";
+        ss << "\"tags\": " << this->_tags << ", ";
+        ss << "\"entry\": \"" << entry << "\", ";
+        ss << "\"score\": "  << certitude << ", ";
+        ss << "\"evt_id\": \"" << evt_id << "\", ";
         ss << "\"details\": ";
         ss << details;
         ss << "}";

--- a/samples/base/AlertManager.cpp
+++ b/samples/base/AlertManager.cpp
@@ -5,8 +5,10 @@
 /// \license  GPLv3
 /// \brief    Copyright (c) 2019 Advens. All rights reserved.
 
+#include <sstream>
 #include "Logger.hpp"
 #include "AlertManager.hpp"
+#include "Time.hpp"
 
 namespace darwin {
 
@@ -123,6 +125,13 @@ namespace darwin {
             this->REDISAddLogs(str);
     }
 
+    void AlertManager::Alert(const std::string& entry,
+               const unsigned int certitude,
+               const std::string& evt_id,
+               const std::string& details) {
+        this->Alert(this->FormatLog(entry, certitude, evt_id, details));
+    }
+
     bool AlertManager::WriteLogs(const std::string& str) {
         DARWIN_LOGGER;
         DARWIN_LOG_DEBUG("AlertManager::WriteLogs:: Starting to write in log file: '"
@@ -171,5 +180,26 @@ namespace darwin {
 
     void AlertManager::Rotate() {
         this->_log_file->Open(true);
+    }
+
+    std::string AlertManager::FormatLog(const std::string& entry,
+                                        const unsigned int certitude,
+                                        const std::string& evt_id,
+                                        const std::string& details) const {
+        std::stringstream ss;
+
+        ss << "{\"alert_type\": \"darwin\",";
+        ss << "\"alert_subtype\": \"" << this->_filter_name << "\",";
+        ss << "\"alert_time\": \"" << darwin::time_utils::GetTime() << "\",";
+        ss << "\"level\": \"high\",";
+        ss << "\"rule_name\": \"" << this->_rule_name << "\",";
+        ss << "\"tags\": " << this->_tags << ",";
+        ss << "\"entry\": \"" << entry << "\",";
+        ss << "\"score\":"  << certitude << ",";
+        ss << "\"evt_id\": \"" << evt_id << "\",";
+        ss << "\"details\": ";
+        ss << details;
+        ss << "}";
+        return ss.str();
     }
 }

--- a/samples/base/AlertManager.cpp
+++ b/samples/base/AlertManager.cpp
@@ -128,8 +128,9 @@ namespace darwin {
     void AlertManager::Alert(const std::string& entry,
                const unsigned int certitude,
                const std::string& evt_id,
-               const std::string& details) {
-        this->Alert(this->FormatLog(entry, certitude, evt_id, details));
+               const std::string& details,
+               const std::string& tags) {
+        this->Alert(this->FormatLog(entry, certitude, evt_id, details, tags));
     }
 
     bool AlertManager::WriteLogs(const std::string& str) {
@@ -185,7 +186,8 @@ namespace darwin {
     std::string AlertManager::FormatLog(const std::string& entry,
                                         const unsigned int certitude,
                                         const std::string& evt_id,
-                                        const std::string& details) const {
+                                        const std::string& details,
+                                        const std::string& tags) const {
         std::stringstream ss;
 
         ss << "{\"alert_type\": \"darwin\", ";
@@ -193,7 +195,12 @@ namespace darwin {
         ss << "\"alert_time\": \"" << darwin::time_utils::GetTime() << "\", ";
         ss << "\"level\": \"high\", ";
         ss << "\"rule_name\": \"" << this->_rule_name << "\", ";
-        ss << "\"tags\": " << this->_tags << ", ";
+
+        if (tags.empty())
+            ss << "\"tags\": " << this->_tags << ", ";
+        else
+            ss << "\"tags\": " << tags << ", ";
+
         ss << "\"entry\": \"" << entry << "\", ";
         ss << "\"score\": "  << certitude << ", ";
         ss << "\"evt_id\": \"" << evt_id << "\", ";

--- a/samples/base/AlertManager.hpp
+++ b/samples/base/AlertManager.hpp
@@ -5,12 +5,17 @@
 /// \license  GPLv3
 /// \brief    Copyright (c) 2019 Advens. All rights reserved.
 
+#pragma once
+
 #include <string>
 #include "../../toolkit/FileManager.hpp"
 #include "../../toolkit/RedisManager.hpp"
 #include "../../toolkit/rapidjson/document.h"
 
-#define DARWIN_RAISE_ALERT(str) darwin::AlertManager::instance().Alert(str)
+#define DARWIN_ALERT_MANAGER darwin::AlertManager::instance()
+#define DARWIN_ALERT_MANAGER_SET_RULE_NAME(str) darwin::AlertManager::instance().SetRuleName(str)
+#define DARWIN_ALERT_MANAGER_SET_FILTER_NAME(str) darwin::AlertManager::instance().SetFilterName(str)
+#define DARWIN_ALERT_MANAGER_SET_TAGS(str) darwin::AlertManager::instance().SetTags(str)
 
 /// \namespace darwin
 namespace darwin {
@@ -30,14 +35,46 @@ namespace darwin {
         /// \param message The alert message.
         void Alert(const std::string& message);
 
+        /// Raise an alert with the given informations.
+        ///
+        /// \param entry The entry that trigered the alert
+        /// \param certitude The score associated to the entry
+        /// \param evt_id The unique id of the event associated to the alert
+        /// \param details A 1 level JSON containing details about the alert
+        void Alert(const std::string& entry,
+                   const unsigned int certitude,
+                   const std::string& evt_id,
+                   const std::string& details = "{}");
+
         /// Configures the AlertManager alerting canals.
         ///
         /// \param configuration The json object containig the whole filter configuration.
         /// \return True on success, false if no alerting canal was configured.
         bool Configure(const rapidjson::Document &configuration);
 
+        inline void SetRuleName(std::string const& rule_name) {
+            this->_rule_name = rule_name;
+        }
+
+        inline void SetFilterName(std::string const& filter_name) {
+            this->_filter_name = filter_name;
+        }
+
+        inline void SetTags(std::string const& tags) {
+            this->_tags = tags;
+        }
+
         /// Close and reopen the alert file to handle log rotate
         void Rotate();
+
+    protected:
+        /// \brief Create the alert JSON
+        /// \param detail A string containing the details json. Defaul is an empty JSON ("{}").
+        /// \return A string containing the alert JSON to log
+        virtual std::string FormatLog(const std::string& entry,
+                                      const unsigned int certitude,
+                                      const std::string& evt_id,
+                                      const std::string& details = "{}") const;
 
     private:
         /// \brief This is the constructor of AlertManager object.
@@ -91,10 +128,13 @@ namespace darwin {
         /// \return True on success, false on error
         bool REDISAddLogs(const std::string& logs);
 
-    private:
+    protected:
         static constexpr unsigned int RETRY = 1;
         bool _log; // If the filter will stock the data in a log file
         bool _redis; // If the filter will stock the data in a REDIS
+        std::string _filter_name;
+        std::string _rule_name;
+        std::string _tags;
         std::string _log_file_path;
         std::string _redis_list_name;
         std::string _redis_channel_name;

--- a/samples/base/AlertManager.hpp
+++ b/samples/base/AlertManager.hpp
@@ -41,10 +41,12 @@ namespace darwin {
         /// \param certitude The score associated to the entry
         /// \param evt_id The unique id of the event associated to the alert
         /// \param details A 1 level JSON containing details about the alert
+        /// \param tags A list containing the tags of the alert
         void Alert(const std::string& entry,
                    const unsigned int certitude,
                    const std::string& evt_id,
-                   const std::string& details = "{}");
+                   const std::string& details = "{}",
+                   const std::string& tags = "");
 
         /// Configures the AlertManager alerting canals.
         ///
@@ -74,7 +76,8 @@ namespace darwin {
         virtual std::string FormatLog(const std::string& entry,
                                       const unsigned int certitude,
                                       const std::string& evt_id,
-                                      const std::string& details = "{}") const;
+                                      const std::string& details = "{}",
+                                      const std::string& tags = "") const;
 
     private:
         /// \brief This is the constructor of AlertManager object.

--- a/samples/base/Core.cpp
+++ b/samples/base/Core.cpp
@@ -101,7 +101,7 @@ namespace darwin {
         opt = -1;
         while((opt = getopt(ac, av, ":l:h")) != -1)
         {
-            DARWIN_LOG_DEBUG("OPT : " + opt);
+            DARWIN_LOG_DEBUG("OPT : " + std::to_string(opt));
             DARWIN_LOG_DEBUG("OPTIND : " + std::to_string(optind));
             switch(opt)
             {

--- a/samples/fanomaly/AnomalyTask.cpp
+++ b/samples/fanomaly/AnomalyTask.cpp
@@ -114,7 +114,7 @@ void AnomalyTask::GenerateAlerts(std::vector<std::string> ips, arma::uvec index_
         details += R"("icmp_nb_host": )" + std::to_string(alerts(ICMP_NB_HOST, i)) + ",";
         details += R"("distance": )" + std::to_string(alerts(DISTANCE, i));
         details += "}";
-        DARWIN_ALERT_MANAGER.Alert(ips[index_anomalies(i)], alerts(DISTANCE, i), Evt_idToString(), details);
+        DARWIN_ALERT_MANAGER.Alert(ips[index_anomalies(i)], 100, Evt_idToString(), details);
     }
 }
 

--- a/samples/fanomaly/AnomalyTask.cpp
+++ b/samples/fanomaly/AnomalyTask.cpp
@@ -96,10 +96,26 @@ bool AnomalyTask::Detection(){
     STAT_MATCH_INC;
     _certitudes.push_back(100);
 
+    GenerateAlerts(_ips, index_anomalies, alerts);
     if(GetOutputType() == darwin::config::output_type::LOG){
         GenerateLogs(_ips, index_anomalies, alerts);
     }
     return true;
+}
+
+void AnomalyTask::GenerateAlerts(std::vector<std::string> ips, arma::uvec index_anomalies, arma::mat alerts){
+    for(unsigned int i=0; i<index_anomalies.n_rows; i++){
+        std::string details;
+        details = R"({"ip": ")" + ips[index_anomalies(i)] + "\",";
+        details += R"("udp_nb_host": )" + std::to_string(alerts(UDP_NB_HOST, i)) + ",";
+        details += R"("udp_nb_port": )" + std::to_string(alerts(UDP_NB_PORT, i)) + ",";
+        details += R"("tcp_nb_host": )" + std::to_string(alerts(TCP_NB_HOST, i)) + ",";
+        details += R"("tcp_nb_port": )" + std::to_string(alerts(TCP_NB_PORT, i)) + ",";
+        details += R"("icmp_nb_host": )" + std::to_string(alerts(ICMP_NB_HOST, i)) + ",";
+        details += R"("distance": )" + std::to_string(alerts(DISTANCE, i));
+        details += "}";
+        DARWIN_ALERT_MANAGER.Alert(ips[index_anomalies(i)], alerts(DISTANCE, i), Evt_idToString(), details);
+    }
 }
 
 void AnomalyTask::GenerateLogs(std::vector<std::string> ips, arma::uvec index_anomalies, arma::mat alerts){
@@ -118,7 +134,6 @@ void AnomalyTask::GenerateLogs(std::vector<std::string> ips, arma::uvec index_an
         alert_log += R"("icmp_nb_host": )" + std::to_string(alerts(ICMP_NB_HOST, i)) + ",";
         alert_log += R"("distance": )" + std::to_string(alerts(DISTANCE, i));
         alert_log += "}}";
-        DARWIN_RAISE_ALERT(alert_log);
         _logs += alert_log + '\n';
     }
 };

--- a/samples/fanomaly/AnomalyTask.hpp
+++ b/samples/fanomaly/AnomalyTask.hpp
@@ -19,6 +19,9 @@
 #include "../../toolkit/lru_cache.hpp"
 
 #define DARWIN_FILTER_ANOMALY 0x414D4C59
+#define DARWIN_FILTER_NAME "anomaly"
+#define DARWIN_ALERT_RULE_NAME "Abnormal Number of Unique Port Connexion"
+#define DARWIN_ALERT_TAGS "[\"attack.discovery\", \"attack.t1046\", \"attack.command_and_control\", \"attack.defense_evasion\", \"attack.t1205\"]"
 
 // To create a usable task method you MUST inherit from darwin::thread::Task publicly.
 // The code bellow show all what's necessary to have a working task.
@@ -44,11 +47,14 @@ private:
     /// Generate the logs from the anomalies found
     void GenerateLogs(std::vector<std::string> ips, arma::uvec index_anomalies, arma::mat alerts);
 
+    /// Generate the alerts from the anomalies found
+    void GenerateAlerts(std::vector<std::string> ips, arma::uvec index_anomalies, arma::mat alerts);
+
     /// The anomaly detection function
     bool Detection();
 
     /// Parse a line from the json body.
-    bool ParseLine(rapidjson::Value &cluster);
+    virtual bool ParseLine(rapidjson::Value &cluster) override final;
 
 private:
     // Indices of values in matrix (see variable "_data" below)

--- a/samples/fanomaly/Generator.cpp
+++ b/samples/fanomaly/Generator.cpp
@@ -5,16 +5,31 @@
 /// \license  GPLv3
 /// \brief    Copyright (c) 2018 Advens. All rights reserved.
 
-#include "base/Logger.hpp"
-#include "Generator.hpp"
-#include "AnomalyTask.hpp"
-
 #include <fstream>
 #include <string>
 
 #include "../../toolkit/lru_cache.hpp"
+#include "base/Logger.hpp"
+#include "Generator.hpp"
+#include "AnomalyTask.hpp"
+#include "AlertManager.hpp"
 
-bool Generator::LoadConfig(const rapidjson::Document &configuration) {
+bool Generator::ConfigureAlterting(const std::string& tags) {
+    DARWIN_LOGGER;
+
+    DARWIN_LOG_DEBUG("Anomaly:: ConfigureAlerting:: Configuring Alerting");
+    DARWIN_ALERT_MANAGER_SET_FILTER_NAME(DARWIN_FILTER_NAME);
+    DARWIN_ALERT_MANAGER_SET_RULE_NAME(DARWIN_ALERT_RULE_NAME);
+    if (tags.empty()) {
+        DARWIN_LOG_DEBUG("Anomaly:: ConfigureAlerting:: No alert tags provided in the configuration. Using default.");
+        DARWIN_ALERT_MANAGER_SET_TAGS(DARWIN_ALERT_TAGS);
+    } else {
+        DARWIN_ALERT_MANAGER_SET_TAGS(tags);
+    }
+    return true;
+}
+
+bool Generator::LoadConfig(const rapidjson::Document &configuration __attribute__((unused))) {
     DARWIN_LOGGER;
     DARWIN_LOG_DEBUG("Anomaly:: Generator:: Configured");
     return true;

--- a/samples/fanomaly/Generator.cpp
+++ b/samples/fanomaly/Generator.cpp
@@ -14,7 +14,7 @@
 #include "AnomalyTask.hpp"
 #include "AlertManager.hpp"
 
-bool Generator::ConfigureAlterting(const std::string& tags) {
+bool Generator::ConfigureAlerting(const std::string& tags) {
     DARWIN_LOGGER;
 
     DARWIN_LOG_DEBUG("Anomaly:: ConfigureAlerting:: Configuring Alerting");

--- a/samples/fanomaly/Generator.hpp
+++ b/samples/fanomaly/Generator.hpp
@@ -22,7 +22,7 @@ public:
 
 public:
     virtual bool LoadConfig(const rapidjson::Document &configuration) override final;
-    virtual bool ConfigureAlterting(const std::string& tags) override final;
+    virtual bool ConfigureAlerting(const std::string& tags) override final;
 
     virtual darwin::session_ptr_t
     CreateTask(boost::asio::local::stream_protocol::socket& socket,

--- a/samples/fanomaly/Generator.hpp
+++ b/samples/fanomaly/Generator.hpp
@@ -22,6 +22,7 @@ public:
 
 public:
     virtual bool LoadConfig(const rapidjson::Document &configuration) override final;
+    virtual bool ConfigureAlterting(const std::string& tags) override final;
 
     virtual darwin::session_ptr_t
     CreateTask(boost::asio::local::stream_protocol::socket& socket,

--- a/samples/fconnection/ConnectionSupervisionTask.cpp
+++ b/samples/fconnection/ConnectionSupervisionTask.cpp
@@ -52,10 +52,10 @@ void ConnectionSupervisionTask::operator()() {
 
             if(certitude >= _threshold and certitude < DARWIN_ERROR_RETURN){
                 STAT_MATCH_INC;
-                std::string alert_log = R"({"evt_id": ")" + Evt_idToString() + R"(", "time": ")" + darwin::time_utils::GetTime() + R"(", "filter": ")" + GetFilterName() +
-                        R"(", "connection": ")" + _connection + R"(", "certitude": )" + std::to_string(certitude) + "}";
-                DARWIN_RAISE_ALERT(alert_log);
+                DARWIN_ALERT_MANAGER.Alert(_connection, certitude, Evt_idToString());
                 if (is_log) {
+                    std::string alert_log = R"({"evt_id": ")" + Evt_idToString() + R"(", "time": ")" + darwin::time_utils::GetTime() + R"(", "filter": ")" + GetFilterName() +
+                            R"(", "connection": ")" + _connection + R"(", "certitude": )" + std::to_string(certitude) + "}";
                     _logs += alert_log + "\n";
                 }
             }

--- a/samples/fconnection/ConnectionSupervisionTask.hpp
+++ b/samples/fconnection/ConnectionSupervisionTask.hpp
@@ -16,6 +16,9 @@
 #include "../toolkit/rapidjson/document.h"
 
 #define DARWIN_FILTER_CONNECTION 0x636E7370
+#define DARWIN_FILTER_NAME "connection"
+#define DARWIN_ALERT_RULE_NAME "New Connection Detection"
+#define DARWIN_ALERT_TAGS "[]"
 
 // To create a usable task method you MUST inherit from darwin::thread::Task publicly.
 // The code bellow show all what's necessary to have a working task.

--- a/samples/fconnection/Generator.cpp
+++ b/samples/fconnection/Generator.cpp
@@ -5,16 +5,31 @@
 /// \license  GPLv3
 /// \brief    Copyright (c) 2018 Advens. All rights reserved.
 
-#include "Generator.hpp"
-#include "base/Logger.hpp"
-#include "ConnectionSupervisionTask.hpp"
-
 #include <regex>
 #include <string>
 #include <fstream>
 
 #include "../../toolkit/lru_cache.hpp"
 #include "../../toolkit/RedisManager.hpp"
+#include "Generator.hpp"
+#include "base/Logger.hpp"
+#include "ConnectionSupervisionTask.hpp"
+#include "AlertManager.hpp"
+
+bool Generator::ConfigureAlterting(const std::string& tags) {
+    DARWIN_LOGGER;
+
+    DARWIN_LOG_DEBUG("Connection:: ConfigureAlerting:: Configuring Alerting");
+    DARWIN_ALERT_MANAGER_SET_FILTER_NAME(DARWIN_FILTER_NAME);
+    DARWIN_ALERT_MANAGER_SET_RULE_NAME(DARWIN_ALERT_RULE_NAME);
+    if (tags.empty()) {
+        DARWIN_LOG_DEBUG("Connection:: ConfigureAlerting:: No alert tags provided in the configuration. Using default.");
+        DARWIN_ALERT_MANAGER_SET_TAGS(DARWIN_ALERT_TAGS);
+    } else {
+        DARWIN_ALERT_MANAGER_SET_TAGS(tags);
+    }
+    return true;
+}
 
 bool Generator::LoadConfig(const rapidjson::Document &configuration) {
     DARWIN_LOGGER;

--- a/samples/fconnection/Generator.cpp
+++ b/samples/fconnection/Generator.cpp
@@ -16,7 +16,7 @@
 #include "ConnectionSupervisionTask.hpp"
 #include "AlertManager.hpp"
 
-bool Generator::ConfigureAlterting(const std::string& tags) {
+bool Generator::ConfigureAlerting(const std::string& tags) {
     DARWIN_LOGGER;
 
     DARWIN_LOG_DEBUG("Connection:: ConfigureAlerting:: Configuring Alerting");

--- a/samples/fconnection/Generator.hpp
+++ b/samples/fconnection/Generator.hpp
@@ -28,6 +28,7 @@ public:
 
 protected:
     virtual bool LoadConfig(const rapidjson::Document &configuration) override final;
+    virtual bool ConfigureAlterting(const std::string& tags) override final;
 
 private:
     bool ConfigRedis(const std::string &redis_socket_path,

--- a/samples/fconnection/Generator.hpp
+++ b/samples/fconnection/Generator.hpp
@@ -28,7 +28,7 @@ public:
 
 protected:
     virtual bool LoadConfig(const rapidjson::Document &configuration) override final;
-    virtual bool ConfigureAlterting(const std::string& tags) override final;
+    virtual bool ConfigureAlerting(const std::string& tags) override final;
 
 private:
     bool ConfigRedis(const std::string &redis_socket_path,

--- a/samples/fdga/DGATask.cpp
+++ b/samples/fdga/DGATask.cpp
@@ -33,7 +33,7 @@ DGATask::DGATask(boost::asio::local::stream_protocol::socket& socket,
                  faup_options_t *faup_options,
                  std::map<std::string, unsigned int> &token_map,
                  const unsigned int max_tokens)
-        : Session{"dga", socket, manager, cache, cache_mutex}, _session{session}, _max_tokens{max_tokens}, _token_map{token_map},
+        : Session{"dga", socket, manager, cache, cache_mutex}, _max_tokens{max_tokens}, _session{session}, _token_map{token_map},
           _faup_options(faup_options) {
     _is_cache = _cache != nullptr;
 }
@@ -71,10 +71,10 @@ void DGATask::operator()() {
                 if (GetCacheResult(hash, certitude)) {
                     if (certitude >= _threshold and certitude < DARWIN_ERROR_RETURN){
                         STAT_MATCH_INC;
-                        std::string alert_log = R"({"evt_id": ")" + Evt_idToString() + R"(", "time": ")" + darwin::time_utils::GetTime() +
-                                R"(", "filter": ")" + GetFilterName() + "\", \"domain\": \""+ _domain + "\", \"dga_prob\": " + std::to_string(certitude) + "}";
-                        DARWIN_RAISE_ALERT(alert_log);
+                        DARWIN_ALERT_MANAGER.Alert(_domain, certitude, Evt_idToString());
                         if (is_log) {
+                            std::string alert_log = R"({"evt_id": ")" + Evt_idToString() + R"(", "time": ")" + darwin::time_utils::GetTime() +
+                                    R"(", "filter": ")" + GetFilterName() + "\", \"domain\": \""+ _domain + "\", \"dga_prob\": " + std::to_string(certitude) + "}";
                             _logs += alert_log + '\n';
                         }
                     }
@@ -88,10 +88,10 @@ void DGATask::operator()() {
             certitude = Predict();
             if (certitude >= _threshold and certitude < DARWIN_ERROR_RETURN){
                 STAT_MATCH_INC;
-                std::string alert_log = R"({"evt_id": ")" + Evt_idToString() + R"(", "time": ")" + darwin::time_utils::GetTime() +
-                                R"(", "filter": ")" + GetFilterName() + "\", \"domain\": \""+ _domain + "\", \"dga_prob\": " + std::to_string(certitude) + "}";
-                DARWIN_RAISE_ALERT(alert_log);
+                DARWIN_ALERT_MANAGER.Alert(_domain, certitude, Evt_idToString());
                 if (is_log) {
+                    std::string alert_log = R"({"evt_id": ")" + Evt_idToString() + R"(", "time": ")" + darwin::time_utils::GetTime() +
+                                    R"(", "filter": ")" + GetFilterName() + "\", \"domain\": \""+ _domain + "\", \"dga_prob\": " + std::to_string(certitude) + "}";
                     _logs += alert_log + '\n';
                 }
             }

--- a/samples/fdga/DGATask.hpp
+++ b/samples/fdga/DGATask.hpp
@@ -19,6 +19,9 @@
 #include "tensorflow/core/public/session.h"
 
 #define DARWIN_FILTER_DGA 0x64676164
+#define DARWIN_FILTER_NAME "dga"
+#define DARWIN_ALERT_RULE_NAME "Domain Generation Algorithm Detection"
+#define DARWIN_ALERT_TAGS "[\"attack.command_and_control\", \"attack.t1483\"]"
 
 // To create a usable task method you MUST inherit from darwin::thread::Task publicly.
 // The code bellow show all what's necessary to have a working task.

--- a/samples/fdga/Generator.cpp
+++ b/samples/fdga/Generator.cpp
@@ -17,14 +17,14 @@
 #include "AlertManager.hpp"
 #include "tensorflow/core/framework/graph.pb.h"
 
-bool Generator::ConfigureAlterting(const std::string& tags) {
+bool Generator::ConfigureAlerting(const std::string& tags) {
     DARWIN_LOGGER;
 
     DARWIN_LOG_DEBUG("DGA:: ConfigureAlerting:: Configuring Alerting");
     DARWIN_ALERT_MANAGER_SET_FILTER_NAME(DARWIN_FILTER_NAME);
     DARWIN_ALERT_MANAGER_SET_RULE_NAME(DARWIN_ALERT_RULE_NAME);
     if (tags.empty()) {
-        DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: No alert tags provided in the configuration. Using default.");
+        DARWIN_LOG_DEBUG("DGA:: ConfigureAlerting:: No alert tags provided in the configuration. Using default.");
         DARWIN_ALERT_MANAGER_SET_TAGS(DARWIN_ALERT_TAGS);
     } else {
         DARWIN_ALERT_MANAGER_SET_TAGS(tags);

--- a/samples/fdga/Generator.cpp
+++ b/samples/fdga/Generator.cpp
@@ -20,7 +20,7 @@
 bool Generator::ConfigureAlterting(const std::string& tags) {
     DARWIN_LOGGER;
 
-    DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: Configuring Alerting");
+    DARWIN_LOG_DEBUG("DGA:: ConfigureAlerting:: Configuring Alerting");
     DARWIN_ALERT_MANAGER_SET_FILTER_NAME(DARWIN_FILTER_NAME);
     DARWIN_ALERT_MANAGER_SET_RULE_NAME(DARWIN_ALERT_RULE_NAME);
     if (tags.empty()) {

--- a/samples/fdga/Generator.cpp
+++ b/samples/fdga/Generator.cpp
@@ -14,7 +14,23 @@
 #include "base/Logger.hpp"
 #include "DGATask.hpp"
 #include "Generator.hpp"
+#include "AlertManager.hpp"
 #include "tensorflow/core/framework/graph.pb.h"
+
+bool Generator::ConfigureAlterting(const std::string& tags) {
+    DARWIN_LOGGER;
+
+    DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: Configuring Alerting");
+    DARWIN_ALERT_MANAGER_SET_FILTER_NAME(DARWIN_FILTER_NAME);
+    DARWIN_ALERT_MANAGER_SET_RULE_NAME(DARWIN_ALERT_RULE_NAME);
+    if (tags.empty()) {
+        DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: No alert tags provided in the configuration. Using default.");
+        DARWIN_ALERT_MANAGER_SET_TAGS(DARWIN_ALERT_TAGS);
+    } else {
+        DARWIN_ALERT_MANAGER_SET_TAGS(tags);
+    }
+    return true;
+}
 
 bool Generator::LoadConfig(const rapidjson::Document &configuration) {
     DARWIN_LOGGER;

--- a/samples/fdga/Generator.hpp
+++ b/samples/fdga/Generator.hpp
@@ -30,7 +30,7 @@ public:
 
 private:
     virtual bool LoadConfig(const rapidjson::Document &configuration) override final;
-    virtual bool ConfigureAlterting(const std::string& tags) override final;
+    virtual bool ConfigureAlerting(const std::string& tags) override final;
     bool LoadFaupOptions();
     bool LoadTokenMap(const std::string &token_map_path);
     bool LoadModel(const std::string &model_path);

--- a/samples/fdga/Generator.hpp
+++ b/samples/fdga/Generator.hpp
@@ -30,6 +30,7 @@ public:
 
 private:
     virtual bool LoadConfig(const rapidjson::Document &configuration) override final;
+    virtual bool ConfigureAlterting(const std::string& tags) override final;
     bool LoadFaupOptions();
     bool LoadTokenMap(const std::string &token_map_path);
     bool LoadModel(const std::string &model_path);

--- a/samples/fhostlookup/Generator.cpp
+++ b/samples/fhostlookup/Generator.cpp
@@ -19,7 +19,7 @@
 #include "AlertManager.hpp"
 
 
-bool Generator::ConfigureAlterting(const std::string& tags) {
+bool Generator::ConfigureAlerting(const std::string& tags) {
     DARWIN_LOGGER;
 
     DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: Configuring Alerting");

--- a/samples/fhostlookup/Generator.cpp
+++ b/samples/fhostlookup/Generator.cpp
@@ -16,7 +16,23 @@
 #include "tsl/hopscotch_set.h"
 #include "../toolkit/rapidjson/document.h"
 #include "../toolkit/rapidjson/istreamwrapper.h"
+#include "AlertManager.hpp"
 
+
+bool Generator::ConfigureAlterting(const std::string& tags) {
+    DARWIN_LOGGER;
+
+    DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: Configuring Alerting");
+    DARWIN_ALERT_MANAGER_SET_FILTER_NAME(DARWIN_FILTER_NAME);
+    DARWIN_ALERT_MANAGER_SET_RULE_NAME(DARWIN_ALERT_RULE_NAME + this->_feed_name);
+    if (tags.empty()) {
+        DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: No alert tags provided in the configuration. Using default.");
+        DARWIN_ALERT_MANAGER_SET_TAGS(DARWIN_ALERT_TAGS);
+    } else {
+        DARWIN_ALERT_MANAGER_SET_TAGS(tags);
+    }
+    return true;
+}
 
 bool Generator::LoadConfig(const rapidjson::Document &configuration) {
     DARWIN_LOGGER;

--- a/samples/fhostlookup/Generator.hpp
+++ b/samples/fhostlookup/Generator.hpp
@@ -13,6 +13,7 @@
 
 #include "Session.hpp"
 #include "AGenerator.hpp"
+#include "HostLookupTask.hpp"
 #include "tsl/hopscotch_map.h"
 #include "tsl/hopscotch_set.h"
 #include "../toolkit/Files.hpp"
@@ -30,6 +31,8 @@ public:
 
 protected:
     virtual bool LoadConfig(const rapidjson::Document &configuration) override final;
+    bool ConfigureAlterting(const std::string& tags) override final;
+
     bool LoadTextFile(const std::string& filename);
     bool LoadJsonFile(const std::string& filename);
     bool LoadJsonDatabase(const rapidjson::Document& database);

--- a/samples/fhostlookup/Generator.hpp
+++ b/samples/fhostlookup/Generator.hpp
@@ -31,7 +31,7 @@ public:
 
 protected:
     virtual bool LoadConfig(const rapidjson::Document &configuration) override final;
-    bool ConfigureAlterting(const std::string& tags) override final;
+    virtual bool ConfigureAlterting(const std::string& tags) override final;
 
     bool LoadTextFile(const std::string& filename);
     bool LoadJsonFile(const std::string& filename);

--- a/samples/fhostlookup/Generator.hpp
+++ b/samples/fhostlookup/Generator.hpp
@@ -31,7 +31,7 @@ public:
 
 protected:
     virtual bool LoadConfig(const rapidjson::Document &configuration) override final;
-    virtual bool ConfigureAlterting(const std::string& tags) override final;
+    virtual bool ConfigureAlerting(const std::string& tags) override final;
 
     bool LoadTextFile(const std::string& filename);
     bool LoadJsonFile(const std::string& filename);

--- a/samples/fhostlookup/HostLookupTask.cpp
+++ b/samples/fhostlookup/HostLookupTask.cpp
@@ -58,9 +58,9 @@ void HostLookupTask::operator()() {
                 if (GetCacheResult(hash, certitude)) {
                     if (certitude >= _threshold and certitude < DARWIN_ERROR_RETURN) {
                         STAT_MATCH_INC;
-                        std::string alert_log = this->BuildAlert(_host, certitude);
-                        DARWIN_RAISE_ALERT(alert_log);
+                        DARWIN_ALERT_MANAGER.Alert(_host, certitude, Evt_idToString(), this->AlertDetails());
                         if (is_log) {
+                            std::string alert_log = this->BuildAlert(_host, certitude);
                             _logs += alert_log + "\n";
                         }
                     }
@@ -74,9 +74,9 @@ void HostLookupTask::operator()() {
             certitude = DBLookup();
             if (certitude >= _threshold and certitude < DARWIN_ERROR_RETURN) {
                 STAT_MATCH_INC;
-                std::string alert_log = this->BuildAlert(_host, certitude);
-                DARWIN_RAISE_ALERT(alert_log);
+                DARWIN_ALERT_MANAGER.Alert(_host, certitude, Evt_idToString(), this->AlertDetails());
                 if (is_log){
+                    std::string alert_log = this->BuildAlert(_host, certitude);
                     _logs += alert_log + "\n";
                 }
             }
@@ -93,6 +93,17 @@ void HostLookupTask::operator()() {
         DARWIN_LOG_DEBUG("HostLookupTask:: processed entry in "
                          + std::to_string(GetDurationMs()) + "ms, certitude: " + std::to_string(_certitudes.back()));
     }
+}
+
+const std::string HostLookupTask::AlertDetails(std::string const& description) {
+    std::stringstream ss;
+
+    ss << "{\"feed_name\": \"" << this->_feed_name << "\"";
+    if (not description.empty()) {
+        ss << ", \"description\": \"" << description << "\"";
+    }
+    ss << "}";
+    return ss.str();
 }
 
 const std::string HostLookupTask::BuildAlert(const std::string& host,

--- a/samples/fhostlookup/HostLookupTask.hpp
+++ b/samples/fhostlookup/HostLookupTask.hpp
@@ -16,6 +16,9 @@
 #include "tsl/hopscotch_set.h"
 
 #define DARWIN_FILTER_HOSTLOOKUP 0x66726570
+#define DARWIN_FILTER_NAME "hostlookup"
+#define DARWIN_ALERT_RULE_NAME "Lookup: "
+#define DARWIN_ALERT_TAGS "[]"
 
 // To create a usable task method you MUST inherit from darwin::thread::Task publicly.
 // The code bellow show all what's necessary to have a working task.
@@ -53,6 +56,8 @@ private:
 
     /// Parse a line from the body.
     bool ParseLine(rapidjson::Value &line) final;
+
+    const std::string AlertDetails(std::string const& descrption = "");
 
 private:
     // This implementation of the hopscotch map allows multiple reader with no writer

--- a/samples/finspection/ContentInspectionTask.cpp
+++ b/samples/finspection/ContentInspectionTask.cpp
@@ -88,12 +88,12 @@ void ContentInspectionTask::operator()() {
                 certitude = 100;
                 if (certitude >= _threshold and certitude < DARWIN_ERROR_RETURN){
                     STAT_MATCH_INC;
-                    std::string alert_log = R"({"evt_id": ")" + Evt_idToString() + R"(", "time": ")" + darwin::time_utils::GetTime() +
-                             R"(", "filter": ")" + GetFilterName() + R"(", "certitude": )" + std::to_string(certitude) + R"(, "yara_match": )" +
-                             std::string(buffer.GetString()) +
-                             "}";
-                    DARWIN_RAISE_ALERT(alert_log);
+                    DARWIN_ALERT_MANAGER.Alert(buffer.GetString(), certitude, Evt_idToString());
                     if (is_log) {
+                        std::string alert_log = R"({"evt_id": ")" + Evt_idToString() + R"(", "time": ")" + darwin::time_utils::GetTime() +
+                                R"(", "filter": ")" + GetFilterName() + R"(", "certitude": )" + std::to_string(certitude) + R"(, "yara_match": )" +
+                                std::string(buffer.GetString()) +
+                                "}";
                         _logs += alert_log + "\n";
                     }
                 }

--- a/samples/finspection/ContentInspectionTask.hpp
+++ b/samples/finspection/ContentInspectionTask.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <string>
+#include <set>
 
 #include "../../toolkit/lru_cache.hpp"
 #include "../../toolkit/rapidjson/stringbuffer.h"
@@ -61,6 +62,9 @@ private:
 
     /// Parse the body received.
     bool ParseBody() override;
+
+    /// Convert a std::set to string json list
+    std::string GetJsonListFromSet(std::set<std::string> &input);
 
     // Implemented but not used.
     bool ParseLine(rapidjson::Value& line __attribute__((unsused))) final {return true;}

--- a/samples/finspection/ContentInspectionTask.hpp
+++ b/samples/finspection/ContentInspectionTask.hpp
@@ -22,6 +22,9 @@
 #include "extract_impcap.hpp"
 
 #define DARWIN_FILTER_CONTENT_INSPECTION 0x79617261
+#define DARWIN_FILTER_NAME "inspection"
+#define DARWIN_ALERT_RULE_NAME "YARA Network Packet & Stream Inspection"
+#define DARWIN_ALERT_TAGS "[]"
 
 typedef struct Configurations_t {
     StreamsCnf *streamsCnf;
@@ -60,7 +63,7 @@ private:
     bool ParseBody() override;
 
     // Implemented but not used.
-    bool ParseLine(rapidjson::Value& line) final {}
+    bool ParseLine(rapidjson::Value& line __attribute__((unsused))) final {return true;}
 
 private:
     Configurations _configurations;

--- a/samples/finspection/Generator.cpp
+++ b/samples/finspection/Generator.cpp
@@ -12,6 +12,7 @@
 #include "../../toolkit/rapidjson/document.h"
 #include "base/Logger.hpp"
 #include "Generator.hpp"
+#include "AlertManager.hpp"
 
 Generator::Generator() {
     poolStorage = initPoolStorage();
@@ -27,6 +28,21 @@ Generator::Generator() {
     startMemoryManager(_memoryManager);
     DARWIN_LOGGER;
     DARWIN_LOG_DEBUG("ContentInspection:: Generator:: successfully initialised");
+}
+
+bool Generator::ConfigureAlterting(const std::string& tags) {
+    DARWIN_LOGGER;
+
+    DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: Configuring Alerting");
+    DARWIN_ALERT_MANAGER_SET_FILTER_NAME(DARWIN_FILTER_NAME);
+    DARWIN_ALERT_MANAGER_SET_RULE_NAME(DARWIN_ALERT_RULE_NAME);
+    if (tags.empty()) {
+        DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: No alert tags provided in the configuration. Using default.");
+        DARWIN_ALERT_MANAGER_SET_TAGS(DARWIN_ALERT_TAGS);
+    } else {
+        DARWIN_ALERT_MANAGER_SET_TAGS(tags);
+    }
+    return true;
 }
 
 bool Generator::LoadConfig(const rapidjson::Document &config) {
@@ -155,7 +171,6 @@ bool Generator::LoadConfig(const rapidjson::Document &config) {
 darwin::session_ptr_t
 Generator::CreateTask(boost::asio::local::stream_protocol::socket& socket,
                       darwin::Manager& manager) noexcept {
-    DARWIN_LOGGER;
     return std::static_pointer_cast<darwin::Session>(
             std::make_shared<ContentInspectionTask>(socket, manager, _cache, _cache_mutex, _configurations));
 }

--- a/samples/finspection/Generator.cpp
+++ b/samples/finspection/Generator.cpp
@@ -30,14 +30,14 @@ Generator::Generator() {
     DARWIN_LOG_DEBUG("ContentInspection:: Generator:: successfully initialised");
 }
 
-bool Generator::ConfigureAlterting(const std::string& tags) {
+bool Generator::ConfigureAlerting(const std::string& tags) {
     DARWIN_LOGGER;
 
-    DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: Configuring Alerting");
+    DARWIN_LOG_DEBUG("ContentInspection:: ConfigureAlerting:: Configuring Alerting");
     DARWIN_ALERT_MANAGER_SET_FILTER_NAME(DARWIN_FILTER_NAME);
     DARWIN_ALERT_MANAGER_SET_RULE_NAME(DARWIN_ALERT_RULE_NAME);
     if (tags.empty()) {
-        DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: No alert tags provided in the configuration. Using default.");
+        DARWIN_LOG_DEBUG("ContentInspection:: ConfigureAlerting:: No alert tags provided in the configuration. Using default.");
         DARWIN_ALERT_MANAGER_SET_TAGS(DARWIN_ALERT_TAGS);
     } else {
         DARWIN_ALERT_MANAGER_SET_TAGS(tags);

--- a/samples/finspection/Generator.hpp
+++ b/samples/finspection/Generator.hpp
@@ -29,6 +29,7 @@ public:
 
 protected:
     virtual bool LoadConfig(const rapidjson::Document &configuration) override final;
+    virtual bool ConfigureAlterting(const std::string& tags) override final;
 
 private:
     Configurations _configurations;

--- a/samples/finspection/Generator.hpp
+++ b/samples/finspection/Generator.hpp
@@ -29,7 +29,7 @@ public:
 
 protected:
     virtual bool LoadConfig(const rapidjson::Document &configuration) override final;
-    virtual bool ConfigureAlterting(const std::string& tags) override final;
+    virtual bool ConfigureAlerting(const std::string& tags) override final;
 
 private:
     Configurations _configurations;

--- a/samples/finspection/yara_utils.hpp
+++ b/samples/finspection/yara_utils.hpp
@@ -27,8 +27,14 @@
 #ifndef YARA_UTILS_H
 #define YARA_UTILS_H
 
+#include <set>
+#include <string>
 #include "stream_buffer.hpp"
-#include "../../toolkit/rapidjson/document.h"
+
+typedef struct YaraResults_ {
+    std::set<std::string> rules;
+    std::set<std::string> tags;
+} YaraResults;
 
 #ifdef __cplusplus
 extern "C" {
@@ -94,7 +100,7 @@ int yaraInitConfig(YaraCnf *);
 int yaraDeleteConfig(YaraCnf *);
 int yaraAddRuleFile(FILE *, const char *, const char *);
 int yaraCompileRules();
-rapidjson::Document yaraScan(uint8_t *, uint32_t, StreamBuffer *);
+YaraResults yaraScan(uint8_t *, uint32_t, StreamBuffer *);
 void yaraErrorCallback(int, const char *, int, const char *, void *);
 int yaraScanOrImportCallback(int, void *, void *);
 

--- a/samples/fsession/Generator.cpp
+++ b/samples/fsession/Generator.cpp
@@ -15,14 +15,14 @@
 #include "SessionTask.hpp"
 #include "AlertManager.hpp"
 
-bool Generator::ConfigureAlterting(const std::string& tags) {
+bool Generator::ConfigureAlerting(const std::string& tags) {
     DARWIN_LOGGER;
 
-    DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: Configuring Alerting");
+    DARWIN_LOG_DEBUG("Session:: ConfigureAlerting:: Configuring Alerting");
     DARWIN_ALERT_MANAGER_SET_FILTER_NAME(DARWIN_FILTER_NAME);
     DARWIN_ALERT_MANAGER_SET_RULE_NAME(DARWIN_ALERT_RULE_NAME);
     if (tags.empty()) {
-        DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: No alert tags provided in the configuration. Using default.");
+        DARWIN_LOG_DEBUG("Session:: ConfigureAlerting:: No alert tags provided in the configuration. Using default.");
         DARWIN_ALERT_MANAGER_SET_TAGS(DARWIN_ALERT_TAGS);
     } else {
         DARWIN_ALERT_MANAGER_SET_TAGS(tags);

--- a/samples/fsession/Generator.cpp
+++ b/samples/fsession/Generator.cpp
@@ -13,6 +13,22 @@
 #include "base/Logger.hpp"
 #include "Generator.hpp"
 #include "SessionTask.hpp"
+#include "AlertManager.hpp"
+
+bool Generator::ConfigureAlterting(const std::string& tags) {
+    DARWIN_LOGGER;
+
+    DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: Configuring Alerting");
+    DARWIN_ALERT_MANAGER_SET_FILTER_NAME(DARWIN_FILTER_NAME);
+    DARWIN_ALERT_MANAGER_SET_RULE_NAME(DARWIN_ALERT_RULE_NAME);
+    if (tags.empty()) {
+        DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: No alert tags provided in the configuration. Using default.");
+        DARWIN_ALERT_MANAGER_SET_TAGS(DARWIN_ALERT_TAGS);
+    } else {
+        DARWIN_ALERT_MANAGER_SET_TAGS(tags);
+    }
+    return true;
+}
 
 bool Generator::LoadConfig(const rapidjson::Document &configuration) {
     DARWIN_LOGGER;

--- a/samples/fsession/Generator.hpp
+++ b/samples/fsession/Generator.hpp
@@ -32,4 +32,5 @@ public:
 
 private:
     virtual bool LoadConfig(const rapidjson::Document &configuration) override final;
+    virtual bool ConfigureAlterting(const std::string& tags) override final;
 };

--- a/samples/fsession/Generator.hpp
+++ b/samples/fsession/Generator.hpp
@@ -32,5 +32,5 @@ public:
 
 private:
     virtual bool LoadConfig(const rapidjson::Document &configuration) override final;
-    virtual bool ConfigureAlterting(const std::string& tags) override final;
+    virtual bool ConfigureAlerting(const std::string& tags) override final;
 };

--- a/samples/fsession/SessionTask.hpp
+++ b/samples/fsession/SessionTask.hpp
@@ -26,7 +26,9 @@ extern "C" {
 
 
 #define DARWIN_FILTER_SESSION 0x73657373
-
+#define DARWIN_FILTER_NAME "session"
+#define DARWIN_ALERT_RULE_NAME "Session"
+#define DARWIN_ALERT_TAGS "[]"
 
 // To create a usable task method you MUST inherit from darwin::thread::Task publicly.
 // The code bellow show all what's necessary to have a working task.

--- a/samples/fsofa/Generator.cpp
+++ b/samples/fsofa/Generator.cpp
@@ -15,14 +15,14 @@
 #include "SofaTask.hpp"
 #include "AlertManager.hpp"
 
-bool Generator::ConfigureAlterting(const std::string& tags) {
+bool Generator::ConfigureAlerting(const std::string& tags) {
     DARWIN_LOGGER;
 
-    DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: Configuring Alerting");
+    DARWIN_LOG_DEBUG("Sofa:: ConfigureAlerting:: Configuring Alerting");
     DARWIN_ALERT_MANAGER_SET_FILTER_NAME(DARWIN_FILTER_NAME);
     DARWIN_ALERT_MANAGER_SET_RULE_NAME(DARWIN_ALERT_RULE_NAME);
     if (tags.empty()) {
-        DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: No alert tags provided in the configuration. Using default.");
+        DARWIN_LOG_DEBUG("Sofa:: ConfigureAlerting:: No alert tags provided in the configuration. Using default.");
         DARWIN_ALERT_MANAGER_SET_TAGS(DARWIN_ALERT_TAGS);
     } else {
         DARWIN_ALERT_MANAGER_SET_TAGS(tags);

--- a/samples/fsofa/Generator.cpp
+++ b/samples/fsofa/Generator.cpp
@@ -13,6 +13,22 @@
 #include "base/Logger.hpp"
 #include "Generator.hpp"
 #include "SofaTask.hpp"
+#include "AlertManager.hpp"
+
+bool Generator::ConfigureAlterting(const std::string& tags) {
+    DARWIN_LOGGER;
+
+    DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: Configuring Alerting");
+    DARWIN_ALERT_MANAGER_SET_FILTER_NAME(DARWIN_FILTER_NAME);
+    DARWIN_ALERT_MANAGER_SET_RULE_NAME(DARWIN_ALERT_RULE_NAME);
+    if (tags.empty()) {
+        DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: No alert tags provided in the configuration. Using default.");
+        DARWIN_ALERT_MANAGER_SET_TAGS(DARWIN_ALERT_TAGS);
+    } else {
+        DARWIN_ALERT_MANAGER_SET_TAGS(tags);
+    }
+    return true;
+}
 
 bool Generator::LoadConfig(const rapidjson::Document &configuration) {
     DARWIN_LOGGER;

--- a/samples/fsofa/Generator.hpp
+++ b/samples/fsofa/Generator.hpp
@@ -34,7 +34,7 @@ public:
 
 protected:
     virtual bool LoadConfig(const rapidjson::Document& configuration) override final;
-    virtual bool ConfigureAlterting(const std::string& tags) override final;
+    virtual bool ConfigureAlerting(const std::string& tags) override final;
 
 private:
     wchar_t *_program_name = nullptr; // the Python environment path to load

--- a/samples/fsofa/Generator.hpp
+++ b/samples/fsofa/Generator.hpp
@@ -34,6 +34,7 @@ public:
 
 protected:
     virtual bool LoadConfig(const rapidjson::Document& configuration) override final;
+    virtual bool ConfigureAlterting(const std::string& tags) override final;
 
 private:
     wchar_t *_program_name = nullptr; // the Python environment path to load

--- a/samples/fsofa/SofaTask.hpp
+++ b/samples/fsofa/SofaTask.hpp
@@ -18,6 +18,9 @@
 #include "FileManager.hpp"
 
 #define DARWIN_FILTER_SOFA 0x72676476
+#define DARWIN_FILTER_NAME "sofa"
+#define DARWIN_ALERT_RULE_NAME "Scan Outlier Finding and Analysis"
+#define DARWIN_ALERT_TAGS "[\"attack.t1200\"]"
 
 // To create a usable task method you MUST inherit from darwin::thread::Task publicly.
 // The code bellow show all what's necessary to have a working task.

--- a/samples/ftanomaly/Generator.cpp
+++ b/samples/ftanomaly/Generator.cpp
@@ -16,14 +16,14 @@
 #include "TAnomalyThreadManager.hpp"
 #include "AlertManager.hpp"
 
-bool Generator::ConfigureAlterting(const std::string& tags) {
+bool Generator::ConfigureAlerting(const std::string& tags) {
     DARWIN_LOGGER;
 
-    DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: Configuring Alerting");
+    DARWIN_LOG_DEBUG("TAnomaly:: ConfigureAlerting:: Configuring Alerting");
     DARWIN_ALERT_MANAGER_SET_FILTER_NAME(DARWIN_FILTER_NAME);
     DARWIN_ALERT_MANAGER_SET_RULE_NAME(DARWIN_ALERT_RULE_NAME);
     if (tags.empty()) {
-        DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: No alert tags provided in the configuration. Using default.");
+        DARWIN_LOG_DEBUG("TAnomaly:: ConfigureAlerting:: No alert tags provided in the configuration. Using default.");
         DARWIN_ALERT_MANAGER_SET_TAGS(DARWIN_ALERT_TAGS);
     } else {
         DARWIN_ALERT_MANAGER_SET_TAGS(tags);

--- a/samples/ftanomaly/Generator.cpp
+++ b/samples/ftanomaly/Generator.cpp
@@ -5,16 +5,31 @@
 /// \license  GPLv3
 /// \brief    Copyright (c) 2018 Advens. All rights reserved.
 
+#include <fstream>
+#include <string>
+
+#include "../../toolkit/lru_cache.hpp"
 #include "base/Logger.hpp"
 #include "base/Core.hpp"
 #include "Generator.hpp"
 #include "TAnomalyTask.hpp"
 #include "TAnomalyThreadManager.hpp"
+#include "AlertManager.hpp"
 
-#include <fstream>
-#include <string>
+bool Generator::ConfigureAlterting(const std::string& tags) {
+    DARWIN_LOGGER;
 
-#include "../../toolkit/lru_cache.hpp"
+    DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: Configuring Alerting");
+    DARWIN_ALERT_MANAGER_SET_FILTER_NAME(DARWIN_FILTER_NAME);
+    DARWIN_ALERT_MANAGER_SET_RULE_NAME(DARWIN_ALERT_RULE_NAME);
+    if (tags.empty()) {
+        DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: No alert tags provided in the configuration. Using default.");
+        DARWIN_ALERT_MANAGER_SET_TAGS(DARWIN_ALERT_TAGS);
+    } else {
+        DARWIN_ALERT_MANAGER_SET_TAGS(tags);
+    }
+    return true;
+}
 
 bool Generator::LoadConfig(const rapidjson::Document &configuration) {
     DARWIN_LOGGER;

--- a/samples/ftanomaly/Generator.hpp
+++ b/samples/ftanomaly/Generator.hpp
@@ -31,7 +31,7 @@ public:
 
 private:
     virtual bool LoadConfig(const rapidjson::Document &configuration) override final;
-    virtual bool ConfigureAlterting(const std::string& tags) override final;
+    virtual bool ConfigureAlerting(const std::string& tags) override final;
 
     std::string _redis_internal = REDIS_INTERNAL_LIST;
     std::shared_ptr<AnomalyThreadManager> _anomaly_thread_manager;

--- a/samples/ftanomaly/Generator.hpp
+++ b/samples/ftanomaly/Generator.hpp
@@ -31,6 +31,7 @@ public:
 
 private:
     virtual bool LoadConfig(const rapidjson::Document &configuration) override final;
+    virtual bool ConfigureAlterting(const std::string& tags) override final;
 
     std::string _redis_internal = REDIS_INTERNAL_LIST;
     std::shared_ptr<AnomalyThreadManager> _anomaly_thread_manager;

--- a/samples/ftanomaly/TAnomalyTask.hpp
+++ b/samples/ftanomaly/TAnomalyTask.hpp
@@ -16,6 +16,10 @@
 #include "../../toolkit/lru_cache.hpp"
 
 #define DARWIN_FILTER_TANOMALY 0x544D4C59
+#define DARWIN_FILTER_NAME "anomaly"
+#define DARWIN_ALERT_RULE_NAME "Abnormal Number of Unique Port Connexion"
+#define DARWIN_ALERT_TAGS "[\"attack.discovery\", \"attack.t1046\", \"attack.command_and_control\", \"attack.defense_evasion\", \"attack.t1205\"]"
+
 
 // To create a usable task method you MUST inherit from darwin::thread::Task publicly.
 // The code bellow show all what's necessary to have a working task.

--- a/samples/ftanomaly/TAnomalyThreadManager.cpp
+++ b/samples/ftanomaly/TAnomalyThreadManager.cpp
@@ -100,7 +100,7 @@ void AnomalyThreadManager::Detection(){
                 + R"("icmp_nb_host": )" + std::to_string(alerts(ICMP_NB_HOST, i)) + ","
                 + R"("distance": )" + std::to_string(alerts(DISTANCE, i))
                 + "}");
-        DARWIN_ALERT_MANAGER.Alert(_ips[index_anomalies(i)], alerts(DISTANCE, i), "-", details);
+        DARWIN_ALERT_MANAGER.Alert(_ips[index_anomalies(i)], 100, "-", details);
     }
     _matrix.reset();
 }

--- a/samples/ftanomaly/TAnomalyThreadManager.cpp
+++ b/samples/ftanomaly/TAnomalyThreadManager.cpp
@@ -92,17 +92,15 @@ void AnomalyThreadManager::Detection(){
 
     for(unsigned int i=0; i<index_anomalies.n_rows; i++){
         STAT_MATCH_INC;
-        std::string log_line(R"({"time": ")" + darwin::time_utils::GetTime() + R"(", "filter": "tanomaly", )"
-                + R"("anomaly": {)"
-                + R"("ip": ")" + _ips[index_anomalies(i)] + "\","
+        std::string details(R"({"ip": ")" + _ips[index_anomalies(i)] + "\","
                 + R"("udp_nb_host": )" + std::to_string(alerts(UDP_NB_HOST, i)) + ","
                 + R"("udp_nb_port": )" + std::to_string(alerts(UDP_NB_PORT, i)) + ","
                 + R"("tcp_nb_host": )" + std::to_string(alerts(TCP_NB_HOST, i)) + ","
                 + R"("tcp_nb_port": )" + std::to_string(alerts(TCP_NB_PORT, i)) + ","
                 + R"("icmp_nb_host": )" + std::to_string(alerts(ICMP_NB_HOST, i)) + ","
                 + R"("distance": )" + std::to_string(alerts(DISTANCE, i))
-                + "}}");
-        DARWIN_RAISE_ALERT(log_line);
+                + "}");
+        DARWIN_ALERT_MANAGER.Alert(_ips[index_anomalies(i)], alerts(DISTANCE, i), "-", details);
     }
     _matrix.reset();
 }

--- a/samples/ftest/Generator.cpp
+++ b/samples/ftest/Generator.cpp
@@ -16,14 +16,14 @@
 #include "tsl/hopscotch_set.h"
 #include "AlertManager.hpp"
 
-bool Generator::ConfigureAlterting(const std::string& tags) {
+bool Generator::ConfigureAlerting(const std::string& tags) {
     DARWIN_LOGGER;
 
-    DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: Configuring Alerting");
+    DARWIN_LOG_DEBUG("Test:: ConfigureAlerting:: Configuring Alerting");
     DARWIN_ALERT_MANAGER_SET_FILTER_NAME(DARWIN_FILTER_NAME);
     DARWIN_ALERT_MANAGER_SET_RULE_NAME(DARWIN_ALERT_RULE_NAME);
     if (tags.empty()) {
-        DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: No alert tags provided in the configuration. Using default.");
+        DARWIN_LOG_DEBUG("Test:: ConfigureAlerting:: No alert tags provided in the configuration. Using default.");
         DARWIN_ALERT_MANAGER_SET_TAGS(DARWIN_ALERT_TAGS);
     } else {
         DARWIN_ALERT_MANAGER_SET_TAGS(tags);

--- a/samples/ftest/Generator.cpp
+++ b/samples/ftest/Generator.cpp
@@ -14,7 +14,22 @@
 #include "TestTask.hpp"
 #include "tsl/hopscotch_map.h"
 #include "tsl/hopscotch_set.h"
+#include "AlertManager.hpp"
 
+bool Generator::ConfigureAlterting(const std::string& tags) {
+    DARWIN_LOGGER;
+
+    DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: Configuring Alerting");
+    DARWIN_ALERT_MANAGER_SET_FILTER_NAME(DARWIN_FILTER_NAME);
+    DARWIN_ALERT_MANAGER_SET_RULE_NAME(DARWIN_ALERT_RULE_NAME);
+    if (tags.empty()) {
+        DARWIN_LOG_DEBUG("Hostlookup:: ConfigureAlerting:: No alert tags provided in the configuration. Using default.");
+        DARWIN_ALERT_MANAGER_SET_TAGS(DARWIN_ALERT_TAGS);
+    } else {
+        DARWIN_ALERT_MANAGER_SET_TAGS(tags);
+    }
+    return true;
+}
 
 bool Generator::LoadConfig(const rapidjson::Document &configuration) {
     DARWIN_LOGGER;

--- a/samples/ftest/Generator.hpp
+++ b/samples/ftest/Generator.hpp
@@ -29,7 +29,7 @@ public:
 
 protected:
     virtual bool LoadConfig(const rapidjson::Document &configuration) override final;
-    virtual bool ConfigureAlterting(const std::string& tags) override final;
+    virtual bool ConfigureAlerting(const std::string& tags) override final;
 
 private:
     bool ConfigRedis(std::string redis_socket_path);

--- a/samples/ftest/Generator.hpp
+++ b/samples/ftest/Generator.hpp
@@ -29,6 +29,7 @@ public:
 
 protected:
     virtual bool LoadConfig(const rapidjson::Document &configuration) override final;
+    virtual bool ConfigureAlterting(const std::string& tags) override final;
 
 private:
     bool ConfigRedis(std::string redis_socket_path);

--- a/samples/ftest/TestTask.cpp
+++ b/samples/ftest/TestTask.cpp
@@ -66,7 +66,7 @@ void TestTask::operator()() {
                 }
             }
             else {
-                DARWIN_RAISE_ALERT(_line);
+                DARWIN_ALERT_MANAGER.Alert(_line, 100, Evt_idToString());
                 _certitudes.push_back(0);
             }
         }
@@ -78,7 +78,7 @@ void TestTask::operator()() {
 
 bool TestTask::REDISAddList(const std::string& list, const std::string& line) {
     DARWIN_LOGGER;
-    
+
     DARWIN_LOG_INFO("TestTask::REDISAddList:: adding '" + line + "' to list '" + list + "'");
     darwin::toolkit::RedisManager& redis = darwin::toolkit::RedisManager::GetInstance();
 
@@ -92,7 +92,7 @@ bool TestTask::REDISAddList(const std::string& list, const std::string& line) {
 
 bool TestTask::REDISPublishChannel(const std::string& channel, const std::string& line) {
     DARWIN_LOGGER;
-    
+
     DARWIN_LOG_INFO("TestTask::REDISPublishChannel:: publishing '" + line + "' to channel '" + channel + "'");
     darwin::toolkit::RedisManager& redis = darwin::toolkit::RedisManager::GetInstance();
 

--- a/samples/ftest/TestTask.hpp
+++ b/samples/ftest/TestTask.hpp
@@ -14,6 +14,9 @@
 #include "Session.hpp"
 
 #define DARWIN_FILTER_TEST 0x74657374
+#define DARWIN_FILTER_NAME "test"
+#define DARWIN_ALERT_RULE_NAME "Test"
+#define DARWIN_ALERT_TAGS "[\"default_test_tag_0\",  \"default_test_tag_1\"]"
 
 // To create a usable task method you MUST inherit from darwin::thread::Task publicly.
 // The code bellow show all what's necessary to have a working task.

--- a/samples/fyara/Generator.cpp
+++ b/samples/fyara/Generator.cpp
@@ -99,6 +99,21 @@ bool Generator::LoadConfig(const rapidjson::Document &configuration) {
     return true;
 }
 
+bool Generator::ConfigureAlerting(const std::string& tags) {
+    DARWIN_LOGGER;
+
+    DARWIN_LOG_DEBUG("Yara:: ConfigureAlerting:: Configuring Alerting");
+    DARWIN_ALERT_MANAGER_SET_FILTER_NAME(DARWIN_FILTER_NAME);
+    DARWIN_ALERT_MANAGER_SET_RULE_NAME(DARWIN_ALERT_RULE_NAME);
+    if (tags.empty()) {
+        DARWIN_LOG_DEBUG("Yara:: ConfigureAlerting:: No alert tags provided in the configuration. Using default.");
+        DARWIN_ALERT_MANAGER_SET_TAGS(DARWIN_ALERT_TAGS);
+    } else {
+        DARWIN_ALERT_MANAGER_SET_TAGS(tags);
+    }
+    return true;
+}
+
 darwin::session_ptr_t
 Generator::CreateTask(boost::asio::local::stream_protocol::socket& socket,
                       darwin::Manager& manager) noexcept {

--- a/samples/fyara/Generator.hpp
+++ b/samples/fyara/Generator.hpp
@@ -13,6 +13,7 @@
 
 #include "Session.hpp"
 #include "AGenerator.hpp"
+#include "AlertManager.hpp"
 #include "../../toolkit/rapidjson/document.h"
 #include "Yara.hpp"
 
@@ -28,6 +29,7 @@ public:
 
 private:
     virtual bool LoadConfig(const rapidjson::Document &configuration) override final;
+    virtual bool ConfigureAlerting(const std::string &tags) override final;
 
 private:
     bool _fastmode;

--- a/samples/fyara/YaraTask.cpp
+++ b/samples/fyara/YaraTask.cpp
@@ -57,7 +57,6 @@ void YaraTask::operator()() {
                     if (certitude>=_threshold and certitude < DARWIN_ERROR_RETURN){
                         STAT_MATCH_INC;
 
-                        DARWIN_ALERT_MANAGER.SetTags("[]");
                         DARWIN_ALERT_MANAGER.Alert("raw_data", certitude, Evt_idToString());
 
                         if (is_log) {
@@ -91,8 +90,7 @@ void YaraTask::operator()() {
                 std::string tagListJson = YaraTask::GetJsonListFromSet(results.tags);
                 std::string details = "{\"rules\": " + ruleListJson + "}";
 
-                DARWIN_ALERT_MANAGER.SetTags(tagListJson);
-                DARWIN_ALERT_MANAGER.Alert("raw_data", certitude, Evt_idToString(),  details);
+                DARWIN_ALERT_MANAGER.Alert("raw_data", certitude, Evt_idToString(),  details, tagListJson);
 
                 if (is_log) {
                     std::string alert_log = R"({"evt_id": ")" + Evt_idToString() + R"(", "time": ")" + darwin::time_utils::GetTime() +

--- a/samples/fyara/YaraTask.hpp
+++ b/samples/fyara/YaraTask.hpp
@@ -21,6 +21,9 @@
 #include "Session.hpp"
 
 #define DARWIN_FILTER_YARA_SCAN 0x79617261
+#define DARWIN_FILTER_NAME "yara"
+#define DARWIN_ALERT_RULE_NAME "Yara scanner"
+#define DARWIN_ALERT_TAGS "[]"
 
 // To create a usable task method you MUST inherit from darwin::thread::Task publicly.
 // The code bellow show all what's necessary to have a working task.
@@ -49,6 +52,9 @@ protected:
 private:
     /// Parse the body received.
     bool ParseLine(rapidjson::Value &line) final;
+
+    /// Convert a std::set to string json list
+    std::string GetJsonListFromSet(std::set<std::string> &input);
 
 private:
     std::string _chunk;

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -1,7 +1,7 @@
 # DARWIN FILES
-MANAGEMENT_SOCKET_PATH = '/var/sockets/darwin/darwin.sock'
-FILTER_SOCKETS_DIR = "/var/sockets/darwin/"
-FILTER_PIDS_DIR = "/var/run/darwin/"
+MANAGEMENT_SOCKET_PATH = '/tmp/sockets/darwin.sock'
+FILTER_SOCKETS_DIR = "/tmp/sockets/"
+FILTER_PIDS_DIR = "/tmp/run/"
 DEFAULT_CONFIGURATION_PATH = '/tmp/darwin.conf'
 
 # ENV CONFIG

--- a/tests/core/alert.py
+++ b/tests/core/alert.py
@@ -173,8 +173,9 @@ def check_file_output(filter: TestFilter, log: str, expected=True) -> bool:
         logging.error("Expected log file to be empty or non existing but got {}".parse(file_content))
         return False
     elif file_content and expected:
-        if log + '\n' in file_content:
-            return True
+        for a in file_content:
+            if log in a:
+                return True
         logging.error("Log not in log file")
         return False
 
@@ -191,8 +192,9 @@ def check_list_output(filter: TestFilter, log: str, expected=True) -> bool:
         return False
     elif alerts and expected:
         alerts = [i.decode() for i in alerts]
-        if log in alerts:
-            return True
+        for a in alerts:
+            if log in a:
+                return True
         logging.error("The given alert could not be found in the Redist alert list")
         return False
 
@@ -202,7 +204,7 @@ def check_channel_output(pubsub, log, expected=True) -> bool:
     if message and expected:
         if message["type"] == "message":
             alert = message["data"].decode()
-            if alert != log:
+            if log not in alert:
                 logging.error("Not the expected alert received in redis. Got {}".format(alert))
                 return False
             return True

--- a/tests/core/redis.py
+++ b/tests/core/redis.py
@@ -38,7 +38,7 @@ def run():
 def simple_master_server():
     master = RedisServer(unix_socket=REDIS_SOCKET_PATH)
 
-    filter = Filter()
+    filter = Filter(filter_name='test')
     filter.configure(FTEST_CONF_TEMPLATE)
     filter.valgrind_start()
 
@@ -66,7 +66,7 @@ def master_replica():
     master = RedisServer(address="127.0.0.1", port=1234)
     replica = RedisServer(address="127.0.0.1", port=1235, unix_socket=REDIS_SOCKET_PATH, master=master)
 
-    filter = Filter()
+    filter = Filter(filter_name='test')
     filter.configure(FTEST_CONF_TEMPLATE)
     filter.valgrind_start()
 
@@ -100,7 +100,7 @@ def master_replica_master_temp_fail():
     master = RedisServer(address="127.0.0.1", port=1234)
     replica = RedisServer(address="127.0.0.1", unix_socket=REDIS_SOCKET_PATH, master=master)
 
-    filter = Filter()
+    filter = Filter(filter_name='test')
     filter.configure(FTEST_CONF_TEMPLATE)
     filter.valgrind_start()
 
@@ -156,7 +156,7 @@ def master_replica_transfer(function_name, healthcheck):
     master = RedisServer(address="127.0.0.1", port=1234)
     replica = RedisServer(address="127.0.0.1", port=1235, unix_socket=REDIS_SOCKET_PATH, master=master)
 
-    filter = Filter()
+    filter = Filter(filter_name='test')
     filter.configure(FTEST_CONF_TEMPLATE)
     filter.valgrind_start()
 
@@ -214,7 +214,7 @@ def master_replica_failover(function_name, healthcheck):
     master = RedisServer(address="127.0.0.1", port=1234)
     replica = RedisServer(unix_socket=REDIS_SOCKET_PATH, master=master)
 
-    filter = Filter()
+    filter = Filter(filter_name='test')
     filter.configure(FTEST_CONF_TEMPLATE)
     filter.valgrind_start()
 
@@ -270,7 +270,7 @@ def master_replica_failover_with_healthcheck():
 def multi_thread_master():
     master = RedisServer(unix_socket=REDIS_SOCKET_PATH)
 
-    filter = Filter(nb_threads=5)
+    filter = Filter(filter_name='test', nb_threads=5)
     filter.configure(FTEST_CONF_TEMPLATE)
     filter.valgrind_start()
 
@@ -310,7 +310,7 @@ def master_replica_discovery_rate_limiting():
     master = RedisServer(address="127.0.0.1", port=1234)
     replica = RedisServer(unix_socket=REDIS_SOCKET_PATH, master=master)
 
-    filter = Filter(nb_threads=5)
+    filter = Filter(filter_name='test', nb_threads=5)
     filter.configure(FTEST_CONF_TEMPLATE)
     filter.start()
 

--- a/tests/filters/ftanomaly.py
+++ b/tests/filters/ftanomaly.py
@@ -352,7 +352,7 @@ def alert_in_redis_test():
             'rule_name': 'Abnormal Number of Unique Port Connexion',
             'tags': ['attack.discovery', 'attack.t1046', 'attack.command_and_control', 'attack.defense_evasion', 'attack.t1205'],
             'entry': '213.211.198.58',
-            'score': 122,
+            'score': 100,
             'evt_id': '-',
             'details': {
                 'ip': '213.211.198.58',
@@ -371,7 +371,7 @@ def alert_in_redis_test():
             'rule_name': 'Abnormal Number of Unique Port Connexion',
             'tags': ['attack.discovery', 'attack.t1046', 'attack.command_and_control', 'attack.defense_evasion', 'attack.t1205'],
             'entry': '192.168.110.2',
-            'score': 349,
+            'score': 100,
             'evt_id': '-',
             'details': {
                 'ip': '192.168.110.2',
@@ -444,7 +444,7 @@ def alert_published_test():
             'rule_name': 'Abnormal Number of Unique Port Connexion',
             'tags': ['attack.discovery', 'attack.t1046', 'attack.command_and_control', 'attack.defense_evasion', 'attack.t1205'],
             'entry': '213.211.198.58',
-            'score': 122,
+            'score': 100,
             'evt_id': '-',
             'details': {
                 'ip': '213.211.198.58',
@@ -463,7 +463,7 @@ def alert_published_test():
             'rule_name': 'Abnormal Number of Unique Port Connexion',
             'tags': ['attack.discovery', 'attack.t1046', 'attack.command_and_control', 'attack.defense_evasion', 'attack.t1205'],
             'entry': '192.168.110.2',
-            'score': 349,
+            'score': 100,
             'evt_id': '-',
             'details': {
                 'ip': '192.168.110.2',
@@ -560,7 +560,7 @@ def alert_in_file_test():
             'rule_name': 'Abnormal Number of Unique Port Connexion',
             'tags': ['attack.discovery', 'attack.t1046', 'attack.command_and_control', 'attack.defense_evasion', 'attack.t1205'],
             'entry': '213.211.198.58',
-            'score': 122,
+            'score': 100,
             'evt_id': '-',
             'details': {
                 'ip': '213.211.198.58',
@@ -579,7 +579,7 @@ def alert_in_file_test():
             'rule_name': 'Abnormal Number of Unique Port Connexion',
             'tags': ['attack.discovery', 'attack.t1046', 'attack.command_and_control', 'attack.defense_evasion', 'attack.t1205'],
             'entry': '192.168.110.2',
-            'score': 349,
+            'score': 100,
             'evt_id': '-',
             'details': {
                 'ip': '192.168.110.2',

--- a/tests/filters/ftanomaly.py
+++ b/tests/filters/ftanomaly.py
@@ -311,8 +311,8 @@ def thread_working_test():
 
 def format_alert(alert, test_name):
         res = json.loads(alert)
-        if "time" in res :
-            del res["time"]
+        if "alert_time" in res :
+            del res["alert_time"]
         else:
             logging.error("{} : No time in the alert : {}.".format(test_name, res))
         return res
@@ -345,17 +345,44 @@ def alert_in_redis_test():
     # Too hard to test with "time" field, so it's removed,
     # but we check in alert received if this field is present
     expected_alerts = [
-        {"filter": "tanomaly",
-         "anomaly":
-         {"ip": "213.211.198.58", "udp_nb_host": 0.000000,
-          "udp_nb_port": 0.000000, "tcp_nb_host": 126.000000, "tcp_nb_port": 126.000000,
-          "icmp_nb_host": 0.000000, "distance": 122.697636}},
-        {"filter": "tanomaly",
-         "anomaly":
-         {"ip": "192.168.110.2", "udp_nb_host": 252.000000,
-          "udp_nb_port": 252.000000, "tcp_nb_host": 0.000000,
-          "tcp_nb_port": 0.000000, "icmp_nb_host": 0.000000,
-          "distance": 349.590273}}
+        {
+            'alert_type': 'darwin',
+            'alert_subtype': 'anomaly',
+            'level': 'high',
+            'rule_name': 'Abnormal Number of Unique Port Connexion',
+            'tags': ['attack.discovery', 'attack.t1046', 'attack.command_and_control', 'attack.defense_evasion', 'attack.t1205'],
+            'entry': '213.211.198.58',
+            'score': 122,
+            'evt_id': '-',
+            'details': {
+                'ip': '213.211.198.58',
+                'udp_nb_host': 0.0,
+                'udp_nb_port': 0.0,
+                'tcp_nb_host': 126.0,
+                'tcp_nb_port': 126.0,
+                'icmp_nb_host': 0.0,
+                'distance': 122.697636
+            }
+        },
+        {
+            'alert_type': 'darwin',
+            'alert_subtype': 'anomaly',
+            'level': 'high',
+            'rule_name': 'Abnormal Number of Unique Port Connexion',
+            'tags': ['attack.discovery', 'attack.t1046', 'attack.command_and_control', 'attack.defense_evasion', 'attack.t1205'],
+            'entry': '192.168.110.2',
+            'score': 349,
+            'evt_id': '-',
+            'details': {
+                'ip': '192.168.110.2',
+                'udp_nb_host': 252.0,
+                'udp_nb_port': 252.0,
+                'tcp_nb_host': 0.0,
+                'tcp_nb_port': 0.0,
+                'icmp_nb_host': 0.0,
+                'distance': 349.590273
+            }
+        }
     ]
 
     redis_alerts = tanomaly_filter.get_redis_alerts()
@@ -410,19 +437,44 @@ def alert_published_test():
     # Too hard to test with "time" field, so it's removed,
     # but we check in alert received if this field is present
     expected_alerts = [
-
-        {"filter": "tanomaly",
-         "anomaly":
-         {"ip": "213.211.198.58", "udp_nb_host": 0.000000,
-          "udp_nb_port": 0.000000, "tcp_nb_host": 126.000000, "tcp_nb_port": 126.000000,
-          "icmp_nb_host": 0.000000, "distance": 122.697636}},
-
-        {"filter": "tanomaly",
-         "anomaly":
-         {"ip": "192.168.110.2", "udp_nb_host": 252.000000,
-          "udp_nb_port": 252.000000, "tcp_nb_host": 0.000000,
-          "tcp_nb_port": 0.000000, "icmp_nb_host": 0.000000,
-          "distance": 349.590273}}
+        {
+            'alert_type': 'darwin',
+            'alert_subtype': 'anomaly',
+            'level': 'high',
+            'rule_name': 'Abnormal Number of Unique Port Connexion',
+            'tags': ['attack.discovery', 'attack.t1046', 'attack.command_and_control', 'attack.defense_evasion', 'attack.t1205'],
+            'entry': '213.211.198.58',
+            'score': 122,
+            'evt_id': '-',
+            'details': {
+                'ip': '213.211.198.58',
+                'udp_nb_host': 0.0,
+                'udp_nb_port': 0.0,
+                'tcp_nb_host': 126.0,
+                'tcp_nb_port': 126.0,
+                'icmp_nb_host': 0.0,
+                'distance': 122.697636
+            }
+        },
+        {
+            'alert_type': 'darwin',
+            'alert_subtype': 'anomaly',
+            'level': 'high',
+            'rule_name': 'Abnormal Number of Unique Port Connexion',
+            'tags': ['attack.discovery', 'attack.t1046', 'attack.command_and_control', 'attack.defense_evasion', 'attack.t1205'],
+            'entry': '192.168.110.2',
+            'score': 349,
+            'evt_id': '-',
+            'details': {
+                'ip': '192.168.110.2',
+                'udp_nb_host': 252.0,
+                'udp_nb_port': 252.0,
+                'tcp_nb_host': 0.0,
+                'tcp_nb_port': 0.0,
+                'icmp_nb_host': 0.0,
+                'distance': 349.590273
+            }
+        }
     ]
 
     try:
@@ -501,18 +553,44 @@ def alert_in_file_test():
     # Too hard to test with "time" field, so it's removed,
     # but we check in alert received if this field is present
     expected_alerts = [
-
-        {"filter": "tanomaly",
-         "anomaly":
-         {"ip": "213.211.198.58", "udp_nb_host": 0.000000,
-          "udp_nb_port": 0.000000, "tcp_nb_host": 126.000000, "tcp_nb_port": 126.000000,
-          "icmp_nb_host": 0.000000, "distance": 122.697636}},
-        {"filter": "tanomaly",
-         "anomaly":
-            {"ip": "192.168.110.2", "udp_nb_host": 252.000000,
-             "udp_nb_port": 252.000000, "tcp_nb_host": 0.000000,
-             "tcp_nb_port": 0.000000, "icmp_nb_host": 0.000000,
-             "distance": 349.590273}}
+        {
+            'alert_type': 'darwin',
+            'alert_subtype': 'anomaly',
+            'level': 'high',
+            'rule_name': 'Abnormal Number of Unique Port Connexion',
+            'tags': ['attack.discovery', 'attack.t1046', 'attack.command_and_control', 'attack.defense_evasion', 'attack.t1205'],
+            'entry': '213.211.198.58',
+            'score': 122,
+            'evt_id': '-',
+            'details': {
+                'ip': '213.211.198.58',
+                'udp_nb_host': 0.0,
+                'udp_nb_port': 0.0,
+                'tcp_nb_host': 126.0,
+                'tcp_nb_port': 126.0,
+                'icmp_nb_host': 0.0,
+                'distance': 122.697636
+            }
+        },
+        {
+            'alert_type': 'darwin',
+            'alert_subtype': 'anomaly',
+            'level': 'high',
+            'rule_name': 'Abnormal Number of Unique Port Connexion',
+            'tags': ['attack.discovery', 'attack.t1046', 'attack.command_and_control', 'attack.defense_evasion', 'attack.t1205'],
+            'entry': '192.168.110.2',
+            'score': 349,
+            'evt_id': '-',
+            'details': {
+                'ip': '192.168.110.2',
+                'udp_nb_host': 252.0,
+                'udp_nb_port': 252.0,
+                'tcp_nb_host': 0.0,
+                'tcp_nb_port': 0.0,
+                'icmp_nb_host': 0.0,
+                'distance': 349.590273
+            }
+        }
     ]
 
     redis_alerts = tanomaly_filter.get_file_alerts()

--- a/tests/manager_socket/utils.py
+++ b/tests/manager_socket/utils.py
@@ -15,7 +15,7 @@ def requests(request):
     try:
         sock.connect(MANAGEMENT_SOCKET_PATH)
     except socket.error as msg:
-        logging.error(msg)
+        logging.error("manager_socket.utils.requests: Could not connect to {}: {}".format(MANAGEMENT_SOCKET_PATH, msg))
         return ""
     try:
         sock.sendall(bytes(request))

--- a/tests/tools/darwin_utils.py
+++ b/tests/tools/darwin_utils.py
@@ -11,12 +11,12 @@ def darwin_start(darwin_manager_path=DEFAULT_MANAGER_PATH, config_path=DEFAULT_C
         '-l',
         'DEBUG',
         '-p',
-        'tmp',
+        '/tmp',
         '--no-suffix-directories',
         config_path
     ])
 
-    sleep(3)
+    sleep(6)
     return process
 
 def darwin_stop(process):

--- a/tests/tools/filter.py
+++ b/tests/tools/filter.py
@@ -16,14 +16,14 @@ REDIS_CHANNEL_NAME = "darwin.tests"
 
 class Filter():
 
-    def __init__(self, path=None, config_file=None, filter_name="filter", socket_path=None, monitoring_socket_path=None, pid_file=None, output="NONE", next_filter_socket_path="no", nb_thread=1, cache_size=0, thresold=101, log_level="DEVELOPER"):
+    def __init__(self, path=None, config_file=None, filter_name="filter", socket_path=None, monitoring_socket_path=None, pid_file=None, output="NONE", next_filter_socket_path="no", nb_threads=1, cache_size=0, thresold=101, log_level="DEVELOPER"):
         self.filter_name = filter_name
         self.socket = socket_path if socket_path else "/tmp/{}.sock".format(filter_name)
         self.config = config_file if config_file else "/tmp/{}.conf".format(filter_name)
         self.path = path if path else "{}darwin_{}".format(DEFAULT_FILTER_PATH, filter_name)
         self.monitor = monitoring_socket_path if monitoring_socket_path else "/tmp/{}_mon.sock".format(filter_name)
         self.pid = pid_file if pid_file else "/tmp/{}.pid".format(filter_name)
-        self.cmd = [self.path, "-l", log_level, self.filter_name, self.socket, self.config, self.monitor, self.pid, output, next_filter_socket_path, str(nb_thread), str(cache_size), str(thresold)]
+        self.cmd = [self.path, "-l", log_level, self.filter_name, self.socket, self.config, self.monitor, self.pid, output, next_filter_socket_path, str(nb_threads), str(cache_size), str(thresold)]
         self.process = None
         self.error_code = 99 # For valgrind testing
         self.pubsub = None

--- a/toolkit/Yara.cpp
+++ b/toolkit/Yara.cpp
@@ -85,32 +85,20 @@ namespace darwin {
             return 0;
         }
 
-        rapidjson::Document YaraEngine::GetResults() {
+        YaraResults YaraEngine::GetResults() {
+            YaraResults results;
+
             const char *yaraRuleTag;
-            rapidjson::Document rules;
-            rapidjson::Document::AllocatorType& alloc = rules.GetAllocator();
 
-            if(_rule_match_list.size() > 0) {
-                rules.SetArray();
+            for(auto rule : _rule_match_list) {
+                results.rules.insert(rule->identifier);
 
-                for(auto rule : _rule_match_list) {
-                    rapidjson::Value ruleJson(rapidjson::kObjectType);
-                    rapidjson::Value tags(rapidjson::kArrayType);
-                    ruleJson.AddMember("rule", rapidjson::StringRef(rule->identifier), alloc);
-
-                    yr_rule_tags_foreach(rule, yaraRuleTag) {
-                        tags.PushBack(rapidjson::StringRef(yaraRuleTag), alloc);
-                    }
-
-                    ruleJson.AddMember("tags", tags, alloc);
-                    rules.PushBack(ruleJson, alloc);
+                yr_rule_tags_foreach(rule, yaraRuleTag) {
+                    results.tags.insert(yaraRuleTag);
                 }
             }
-            else {
-                rules.SetNull();
-            }
 
-            return rules;
+            return results;
         }
 
         int YaraEngine::ScanOrImportCallback(int message, void *messageData, void *userData) {

--- a/toolkit/Yara.hpp
+++ b/toolkit/Yara.hpp
@@ -14,6 +14,11 @@ namespace darwin {
 
     namespace toolkit {
 
+        typedef struct YaraResults_ {
+            std::set<std::string> rules;
+            std::set<std::string> tags;
+        } YaraResults;
+
         class YaraEngine {
         public:
             /// The YaraEngine constructor
@@ -37,10 +42,11 @@ namespace darwin {
             /// \warning the engine should be initialised with Init() first
             int ScanData(std::vector<unsigned char> &data, unsigned int &certitude);
 
-            /// Gets a rapidjson document with the results from the last scan
-            /// the results are formated directly as an array
-            /// \return the rapidjson document in the form [{"rule": "_rule_name_", "tags": ["_tag1_", "_tag2_", ...]}]
-            rapidjson::Document GetResults();
+            /// Gets a structure with the results from the last scan
+            /// the structure contains 2 sets:
+            /// - a rules object containing all the matching rules
+            /// - a tags object containing the aggregated tags from all the rules matching
+            YaraResults GetResults();
 
         private:
             /// A callback to get information from the yara library during the scan


### PR DESCRIPTION
# :sparkles: Pull Request Template
:bangbang: Once all the **checklist** is **done** you have to:
  * **stash merge** this pull request
  * **delete** the corresponding **branch**
  * **close** the associated **issue**

## :page_with_curl: Type of change

**Bug fix**: non-breaking change which fixes an issue.
**Breaking change**: fix or feature that would cause existing functionality to not work as expected.

## :bulb: Related Issue(s)

- Resolve #155 

## :black_nib: Description

### Breaking Changes
**BREAKING**: The existing alert format is replaced by a more uniform one.

The goal is to make it easier to read, parse, query and display.
The alert formatting is no longer hard coded in the filters to avoid mistakes.

The ability to add tags to the alert raised was implemented.
By default  the filters might contains some MITRE tags indicating plausible threats type.
It can be configured through the `alert_tags` optional string list.

### The new alert format
```
{
    "alert_type": "darwin",
    "alert_subtype": "<filter_name>",
    "alert_time": "<ISO8601>",
    "level": "high",
    "rule_name": "<rule_name>",
    "tags": ["<tag_0>", "<tag_1>", ...],
    "entry": "<filter_input>",
    "score": <integer>,
    "details": {
        "feed": "<the_threat_intell_feed_name>",
        "description": "<threat_description>",
        "udp_nb_host": <float, number of unique host connected via udp>,
        "udp_nb_port": <float, number of unique port connected via udp>,
        "tcp_nb_host": <float, number of unique host connected via tcp>,
        "tcp_nb_port": <float, number of unique port connected via tcp>,
        "distance": <float, distance to the closest normal asset>
    }
}
```
The `rule_name` contains a short description of the alert for display purposes.

The fields in the `details` json will vary given the filter raising the alert.
Refer to the filter's documentation for details.

### Fixes
- FAnomaly, alert was not raised when the output format was not `LOG`.
- Multiple compilation warnings.
- Issues with a recent merge in the automated testing.
- Multiple missing parameters errors in the manager.

## :dart: Test Environments

### HardenedBSD 12-STABLE
- Redis 5.0.8
- Boost 1.72.0
- clang++ 9.0.1
- CMake 3.17.1
- Python 3.7.7

## :heavy_check_mark: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added corresponding page to the documentation
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

</br>

- [x] :raising_hand: **I certify on my honor that all the information provided is true, and I've done all I can to deliver a high quality code**
