### PR TITLE
CONTENT_INSPECTION:: add compatibility to yara v4 for content_inspection

### DIFF
--- a/samples/finspection/yara_utils.hpp
+++ b/samples/finspection/yara_utils.hpp
@@ -101,8 +101,14 @@ int yaraDeleteConfig(YaraCnf *);
 int yaraAddRuleFile(FILE *, const char *, const char *);
 int yaraCompileRules();
 YaraResults yaraScan(uint8_t *, uint32_t, StreamBuffer *);
+
+#if YR_MAJOR_VERSION == 3
 void yaraErrorCallback(int, const char *, int, const char *, void *);
 int yaraScanOrImportCallback(int, void *, void *);
+#elif YR_MAJOR_VERSION == 4
+void yaraErrorCallback(int, const char *, int, const YR_RULE *, const char *, void *);
+int yaraScanOrImportCallback(YR_SCAN_CONTEXT *, int, void *, void *);
+#endif
 
 #ifdef __cplusplus
 };


### PR DESCRIPTION
# :sparkles: add compatibility to yara v4 for content_inspection
:bangbang: Once all the **checklist** is **done** you have to:
  * **stash merge** this pull request
  * **delete** the corresponding **branch**
  * **close** the associated **issue**

## :page_with_curl: Type of change

Please delete options that are not relevant.

**Hotfix**: exceptional fix solving a blocking issue.


## :black_nib: Description

HardenedBSD has updated its yara package to the 4.0.2 version, as such current release and development versions of **content_inspection** are broken when compiling on HBSD.
This PR updates the yara API calls to be compliant with both yara version 3 and 4.

## :dart: Test Environments

### HardenedBSD (12-STABLE)
- clang++ (9.0.1)
- Cmake (3.17.3_1)
- yara (4.0.2)

### Ubuntu (18.04)
- g++ (7.5.0)
- CMake (3.10.2)
- libyara (4.0.2)
- Valgrind (3.13.0)

## :heavy_check_mark: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] (**If other changes**) I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

</br>

- [x] :raising_hand: **I certify on my honor that all the information provided is true, and I've done all I can to deliver a high quality code**
