### PR TITLE
hotfix:: add compatibility with yara API v4

### DIFF
--- a/samples/finspection/file_utils.hpp
+++ b/samples/finspection/file_utils.hpp
@@ -45,9 +45,7 @@ extern "C" {
 #include <pthread.h>
 #include <libgen.h>
 
-#ifdef __gnu_linux__
 #include <assert.h>
-#endif
 
 typedef struct FileStruct_ {
     char *directory;

--- a/samples/finspection/yara_utils.hpp
+++ b/samples/finspection/yara_utils.hpp
@@ -101,8 +101,14 @@ int yaraDeleteConfig(YaraCnf *);
 int yaraAddRuleFile(FILE *, const char *, const char *);
 int yaraCompileRules();
 YaraResults yaraScan(uint8_t *, uint32_t, StreamBuffer *);
+
+#if YR_MAJOR_VERSION == 3
 void yaraErrorCallback(int, const char *, int, const char *, void *);
 int yaraScanOrImportCallback(int, void *, void *);
+#elif YR_MAJOR_VERSION == 4
+void yaraErrorCallback(int, const char *, int, const YR_RULE *, const char *, void *);
+int yaraScanOrImportCallback(YR_SCAN_CONTEXT *, int, void *, void *);
+#endif
 
 #ifdef __cplusplus
 };

--- a/toolkit/Yara.hpp
+++ b/toolkit/Yara.hpp
@@ -49,11 +49,20 @@ namespace darwin {
             YaraResults GetResults();
 
         private:
+#if YR_MAJOR_VERSION == 3
             /// A callback to get information from the yara library during the scan
             /// \param message the type of message received
             /// \param messageData a pointer on the data returned, depending on _message_
             /// \param userData a pointer on previously configured data to return with the message
             static int ScanOrImportCallback(int message, void *messageData, void *userData);
+#elif YR_MAJOR_VERSION == 4
+            /// A callback to get information from the yara library during the scan
+            /// \param context unused necessary parameter for yara API v4
+            /// \param message the type of message received
+            /// \param messageData a pointer on the data returned, depending on _message_
+            /// \param userData a pointer on previously configured data to return with the message
+            static int ScanOrImportCallback(YR_SCAN_CONTEXT *context, int message, void *messageData, void *userData);
+#endif
 
             /// A simple function to add a rule to the list of matching rules
             /// \param rule a pointer on the rule to add
@@ -109,7 +118,12 @@ namespace darwin {
             std::shared_ptr<YaraEngine> GetEngine(bool fastmode = false, int timeout = 0);
 
         private:
+#if YR_MAJOR_VERSION == 3
             static void YaraErrorCallback(int errorLevel, const char *filename, int lineNumber, const char *message, void *userData);
+#elif YR_MAJOR_VERSION == 4
+            static void YaraErrorCallback(int errorLevel, const char *filename, int lineNumber, const YR_RULE *rule, const char *message, void *userData);
+#endif
+
 
         private:
             YR_COMPILER *_compiler = nullptr; //Yara compiler


### PR DESCRIPTION
# :sparkles: hotfix:: add compatibility with yara API v4
:bangbang: Once all the **checklist** is **done** you have to:
  * **stash merge** this pull request
  * **delete** the corresponding **branch**
  * **close** the associated **issue**

## :page_with_curl: Type of change

Please delete options that are not relevant.

**Hotfix**: Exceptional fix that resolves problems occurring in releases.


## :black_nib: Description

Adds compatibility with Yara API 4.x for the fcontent_inspection and fyara filters.
This is a hotfix as HardenedBSD 12 has released yara v4.0.2 on its repositories, requiring the filters to be compatible with the 4.x version to compile properly, and for vulture to be upgraded without breaking.

## :dart: Test Environments

### HardenedBSD (12-STABLE)
- clang++ (10.0.0)
- CMake (3.17.2)
- yara (3.11.0/4.0.2)

### FreeBSD (12.0-RELEASE)
- clang++ (6.0.1)
- CMake (3.17.3)
- yara (3.11.0)

### Ubuntu (18.04)
- g++ (7.5.0)
- CMake (3.10.2)
- yara (3.11.0/4.0.2)
- Valgrind (3.13.0)

## :heavy_check_mark: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] (**If other changes**) I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

</br>

- [x] :raising_hand: **I certify on my honor that all the information provided is true, and I've done all I can to deliver a high quality code**
