### PR TITLE
FHOSTLOOKUP:: FIX ABSENT FEED_NAME IN CASE OF NON-TEXT DB

### DIFF
--- a/samples/fhostlookup/Generator.hpp
+++ b/samples/fhostlookup/Generator.hpp
@@ -42,6 +42,7 @@ protected:
 
     bool LoadTextFile(const std::string& filename);
     bool LoadJsonFile(const std::string& filename, const db_type type);
+    void LoadFeedNameFromFile(const std::string& filename);
     bool LoadJsonDatabase(const rapidjson::Document& database);
     bool LoadJsonEntry(const rapidjson::Value& entry);
     bool LoadRsyslogDatabase(const rapidjson::Document& database);


### PR DESCRIPTION
# :sparkles: FHOSTLOOKUP:: FIX ABSENT FEED_NAME IN CASE OF NON-TEXT DB
:bangbang: Once all the **checklist** is **done** you have to:
  * **stash merge** this pull request
  * **delete** the corresponding **branch**
  * **close** the associated **issue**

## :page_with_curl: Type of change

Please delete options that are not relevant.

**Bug fix**: non-breaking change which fixes an issue.

## :bulb: Related Issue(s)

- Resolve #201 

## :black_nib: Description

Fixes the absence of feed name when the hostlookup filter uses a "json" or "rsyslog" type database.

## :dart: Test Environments

### HBSD (12.1)
- clang++ 10.0.0
- CMake 3.17.3
- Python 3.7

### Ubuntu (18.04)
- g++  7.5.0
- CMake 3.10.2
- Python 3.6
- Valgrind 3.13.0

## :heavy_check_mark: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes

</br>

- [x] :raising_hand: **I certify on my honor that all the information provided is true, and I've done all I can to deliver a high quality code**
