### PR TITLE
REMOVING 'MATCH' STAT FROM BUFFER

### DIFF
--- a/samples/fbuffer/BufferTask.cpp
+++ b/samples/fbuffer/BufferTask.cpp
@@ -41,7 +41,6 @@ void BufferTask::operator()() {
     for (rapidjson::Value &line : array) {
         STAT_INPUT_INC;
         if (ParseLine(line)) {
-            STAT_MATCH_INC;
             this->_certitudes.push_back(0);
             this->AddEntries();
         } else {


### PR DESCRIPTION
# :sparkles: Pull Request Template
:bangbang: Once all the **checklist** is **done** you have to:
  * **stash merge** this pull request
  * **delete** the corresponding **branch**
  * **close** the associated **issue**

## :page_with_curl: Type of change

**Bug fix**: non-breaking change which fixes an issue.

## :bulb: Related Issue(s)

- Resolve #213

## :black_nib: Description

Removing the modification of the wrong statistic value in fbuffer.

## :dart: Test Environments

### HardenedBSD 12.1
- Redis 5.0.9
- Boost 1.72.0
- clang++ 10.0.0
- CMake 3.17.3
- Python 3.7

## :heavy_check_mark: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

</br>

- [x] :raising_hand: **I certify on my honor that all the information provided is true, and I've done all I can to deliver a high quality code**
