### PR TITLE
Avoid Manager crashing when updating a configuration with syntax errors

### DIFF
--- a/manager/Services.py
+++ b/manager/Services.py
@@ -322,10 +322,9 @@ class Services:
         try:
             #Reload conf, global variable 'conf_filters' will be updated
             load_conf(prefix, suffix)
-        except ConfParseError:
-            error = "Update: wrong configuration format, unable to update"
-            logger.error(error)
-            return error
+        except ConfParseError as e:
+            logger.error("Update: Unable to update: {}".format(e))
+            return [str(e)]
 
         logger.info("Update: Configuration loaded")
 

--- a/manager/config.py
+++ b/manager/config.py
@@ -233,14 +233,14 @@ def load_conf(prefix, suffix, conf=""):
             configuration = json.load(f)
     except Exception as e:
         logger.critical("Configurator: Unable to load configuration: {}".format(e))
-        raise e
+        raise ConfParseError("Incorrect configuration format: {}".format(e))
 
     if configuration.get('version'):
         logger.debug("Configurator: found a 'version' field, trying v2 format...")
         try:
             custom_validator(conf_v2_schema).validate(configuration)
         except Exception as e:
-            raise ConfParseError("Incorrect configuration format: {}".format(e.message))
+            raise ConfParseError("Incorrect configuration format: {}".format(e))
         filters.clear()
         stats_reporting.clear()
         stats_reporting.update(configuration['report_stats'])
@@ -252,7 +252,7 @@ def load_conf(prefix, suffix, conf=""):
         try:
             custom_validator(conf_v1_schema).validate(configuration)
         except Exception as e:
-            raise ConfParseError("Incorrect configuration format: {}".format(e.message))
+            raise ConfParseError("Incorrect configuration format: {}".format(e))
         stats_reporting.clear()
         filters.clear()
         filters.update(configuration)

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -1,14 +1,10 @@
-# DARWIN FILES
-MANAGEMENT_SOCKET_PATH = '/var/sockets/darwin/darwin.sock'
-FILTER_SOCKETS_DIR = "/var/sockets/darwin/"
-FILTER_PIDS_DIR = "/var/run/darwin/"
-DEFAULT_CONFIGURATION_PATH = '/tmp/darwin.conf'
+# Where all Runtime and temporary files will be put (configurations, sockets, pid files, logging files... except darwin.log)
+TEST_FILES_DIR = '/tmp'
 
 # ENV CONFIG
 PYTHON_ENV_PATH = "/usr/local/lib/python3.7"
 DEFAULT_PYTHON_EXEC = 'python3'
 
-TEST_FILES_DIR = '/tmp'
 DEFAULT_MANAGER_PATH = '/home/darwin/manager/manager.py'
 DEFAULT_FILTER_PATH = '/home/darwin/filters/'
 

--- a/tests/manager_socket/update_test.py
+++ b/tests/manager_socket/update_test.py
@@ -7,6 +7,8 @@ from tools.output import print_result
 
 def run():
     tests = [
+        wrong_manager_conf,
+        wrong_manager_conf_v2,
         no_filter_to_none,
         no_filter_to_one,
         no_filter_to_one_conf_v2,
@@ -22,30 +24,66 @@ def run():
         one_update_none_conf_v2,
         one_update_one,
         one_update_one_conf_v2,
-        one_update_one_wrong_conf,
-        one_update_one_wrong_conf_conf_v2,
+        one_update_one_wrong_filter_conf,
+        one_update_one_wrong_filter_conf_v2,
         many_update_none,
         many_update_none_conf_v2,
         many_update_one,
         many_update_one_conf_v2,
         many_update_many,
         many_update_many_conf_v2,
-        many_update_two_wrong_conf_conf_v2,
-        many_update_two_wrong_conf,
+        many_update_two_wrong_filter_conf,
+        many_update_two_wrong_filter_conf_v2,
         many_update_all,
         many_update_all_conf_v2,
-        many_update_all_wrong_conf,
-        many_update_all_wrong_conf_conf_v2,
+        many_update_all_wrong_filter_conf,
+        many_update_all_wrong_filter_conf_v2,
         non_existing_filter,
         non_existing_filter_conf_v2,
         update_no_filter,
         many_update_diff_one_more_v2,
         many_update_diff_one_less_v2,
         many_update_diff_one_more_one_less_v2,
+        one_update_one_wrong_manager_conf,
+        one_update_one_wrong_manager_conf_v2,
+        many_update_all_wrong_manager_conf,
+        many_update_all_wrong_manager_conf_v2,
+        many_update_two_less_wrong_then_good_manager_conf
     ]
 
     for i in tests:
         print_result("Update: " + i.__name__, i)
+
+
+def wrong_manager_conf():
+    ret = True
+
+    darwin_configure(CONF_ONE + "this is no valid JSON")
+    process = darwin_start()
+
+    sleep(1)
+    darwin_stop(process)
+    if process.returncode != 1:
+        logging.error("wrong_manager_conf: manager didn't return an error for the wrong configuration")
+        ret = False
+
+    darwin_remove_configuration()
+    return ret
+
+def wrong_manager_conf_v2():
+    ret = True
+
+    darwin_configure(CONF_ONE_V2 + "this is still not a valid JSON")
+    process = darwin_start()
+
+    sleep(1)
+    darwin_stop(process)
+    if process.returncode != 1:
+        logging.error("wrong_manager_conf_v2: manager didn't return an error for the wrong configuration")
+        ret = False
+
+    darwin_remove_configuration()
+    return ret
 
 
 def no_filter_to_none():
@@ -112,19 +150,19 @@ def no_filter_to_one_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if RESP_EMPTY not in resp:
-        logging.error("no_filter_to_one: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("no_filter_to_one_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_configure(CONF_ONE_V2)
     darwin_configure(CONF_FTEST, path=PATH_CONF_FTEST)
     resp = requests(REQ_UPDATE_ONE)
     if RESP_STATUS_OK not in resp:
-        logging.error("no_filter_to_one: Update response error; got \"{}\"".format(resp))
+        logging.error("no_filter_to_one_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if RESP_TEST_1 not in resp:
-        logging.error("no_filter_to_one: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("no_filter_to_one_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -171,19 +209,19 @@ def no_filter_to_many_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if RESP_EMPTY not in resp:
-        logging.error("no_filter_to_many: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("no_filter_to_many_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_configure(CONF_THREE_V2)
     darwin_configure(CONF_FTEST, path=PATH_CONF_FTEST)
     resp = requests(REQ_UPDATE_THREE)
     if RESP_STATUS_OK not in resp:
-        logging.error("no_filter_to_many: Update response error; got \"{}\"".format(resp))
+        logging.error("no_filter_to_many_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("no_filter_to_many: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("no_filter_to_many_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -230,18 +268,18 @@ def one_filter_to_none_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if RESP_TEST_1 not in resp:
-        logging.error("one_filter_to_none: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_filter_to_none_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_configure(CONF_EMPTY)
     resp = requests(REQ_UPDATE_ONE)
     if RESP_STATUS_OK not in resp:
-        logging.error("one_filter_to_none: Update response error; got \"{}\"".format(resp))
+        logging.error("one_filter_to_none_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if RESP_EMPTY not in resp:
-        logging.error("one_filter_to_none: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_filter_to_none_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -288,18 +326,18 @@ def many_filters_to_none_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("many_filters_to_none: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_filters_to_none_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_configure(CONF_EMPTY)
     resp = requests(REQ_UPDATE_THREE)
     if RESP_STATUS_OK not in resp:
-        logging.error("many_filters_to_none: Update response error; got \"{}\"".format(resp))
+        logging.error("many_filters_to_none_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if RESP_EMPTY not in resp:
-        logging.error("many_filters_to_none: Mismatching second monitor response; got \"{}\"".format(resp))
+        logging.error("many_filters_to_none_conf_v2: Mismatching second monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -350,20 +388,20 @@ def many_filters_to_one_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("many_filters_to_one: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_filters_to_one_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(1) # Need this because of the starting delay
     darwin_configure(CONF_ONE_V2)
     resp = requests(REQ_UPDATE_TWO)
     if RESP_STATUS_OK not in resp:
-        logging.error("many_filters_to_one: Update response error; got \"{}\"".format(resp))
+        logging.error("many_filters_to_one_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     sleep(1)
     resp = requests(REQ_MONITOR)
     if RESP_TEST_1 not in resp:
-        logging.error("many_filters_to_one: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_filters_to_one_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -413,19 +451,19 @@ def one_update_none_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if RESP_TEST_1 not in resp:
-        logging.error("one_update_none: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_update_none_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(1) # Need this because of the starting delay
     resp = requests(REQ_UPDATE_EMPTY)
     if RESP_STATUS_OK not in resp:
-        logging.error("one_update_none: Update response error; got \"{}\"".format(resp))
+        logging.error("one_update_none_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     sleep(1) # Need this because of the starting delay
     resp = requests(REQ_MONITOR)
     if RESP_TEST_1 not in resp:
-        logging.error("one_update_none: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_update_none_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -475,19 +513,19 @@ def one_update_one_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if RESP_TEST_1 not in resp:
-        logging.error("one_update_one: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_update_one_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(2) # Need this because of the starting delay
     resp = requests(REQ_UPDATE_ONE)
     if RESP_STATUS_OK not in resp:
-        logging.error("one_update_one: Update response error; got \"{}\"".format(resp))
+        logging.error("one_update_one_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     sleep(1) # Need this because of the starting delay
     resp = requests(REQ_MONITOR)
     if RESP_TEST_1 not in resp:
-        logging.error("one_update_one: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_update_one_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -496,7 +534,7 @@ def one_update_one_conf_v2():
     return ret
 
 
-def one_update_one_wrong_conf():
+def one_update_one_wrong_filter_conf():
 
     ret = True
 
@@ -506,23 +544,23 @@ def one_update_one_wrong_conf():
 
     resp = requests(REQ_MONITOR)
     if RESP_TEST_1 not in resp:
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_update_one_wrong_filter_conf: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(2) # Need this because of the starting delay
     darwin_configure(CONF_FTEST_WRONG_CONF, path=PATH_CONF_FTEST)
     resp = requests(REQ_UPDATE_ONE)
     if RESP_STATUS_KO not in resp:
-        logging.error("one_update_one_wrong_conf: Update response error; got \"{}\"".format(resp))
+        logging.error("one_update_one_wrong_filter_conf: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if RESP_TEST_1 not in resp:
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_update_one_wrong_filter_conf: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     if not check_filter_files("test_1", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("one_update_one_wrong_filter_conf: filter files check failed")
         ret = False
 
     darwin_stop(process)
@@ -531,7 +569,7 @@ def one_update_one_wrong_conf():
     return ret
 
 
-def one_update_one_wrong_conf_conf_v2():
+def one_update_one_wrong_filter_conf_v2():
 
     ret = True
 
@@ -541,23 +579,23 @@ def one_update_one_wrong_conf_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if RESP_TEST_1 not in resp:
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_update_one_wrong_filter_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(2) # Need this because of the starting delay
     darwin_configure(CONF_FTEST_WRONG_CONF, path=PATH_CONF_FTEST)
     resp = requests(REQ_UPDATE_ONE)
     if RESP_STATUS_KO not in resp:
-        logging.error("one_update_one_wrong_conf: Update response error; got \"{}\"".format(resp))
+        logging.error("one_update_one_wrong_filter_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if RESP_TEST_1 not in resp:
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_update_one_wrong_filter_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     if not check_filter_files("test_1", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("one_update_one_wrong_filter_conf_v2: filter files check failed")
         ret = False
 
     darwin_stop(process)
@@ -606,18 +644,18 @@ def many_update_none_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("many_update_none: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_none_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(1) # Need this because of the starting delay
     resp = requests(REQ_UPDATE_EMPTY)
     if RESP_STATUS_OK not in resp:
-        logging.error("many_update_none: Update response error; got \"{}\"".format(resp))
+        logging.error("many_update_none_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("many_update_none: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_none_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -666,18 +704,18 @@ def many_update_one_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("many_update_one: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_one_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(1) # Need this because of the starting delay
     resp = requests(REQ_UPDATE_ONE)
     if RESP_STATUS_OK not in resp:
-        logging.error("many_update_one: Update response error; got \"{}\"".format(resp))
+        logging.error("many_update_one_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("many_update_one: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_one_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -724,18 +762,18 @@ def many_update_many_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("many_update_many: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_many_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(1) # Need this because of the starting delay
     resp = requests(REQ_UPDATE_TWO)
     if RESP_STATUS_OK not in resp:
-        logging.error("many_update_many: Update response error; got \"{}\"".format(resp))
+        logging.error("many_update_many_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("many_update_many: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_many_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -744,7 +782,7 @@ def many_update_many_conf_v2():
     return ret
 
 
-def many_update_two_wrong_conf():
+def many_update_two_wrong_filter_conf():
 
     ret = True
 
@@ -754,27 +792,27 @@ def many_update_two_wrong_conf():
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_update_one_wrong_filter_conf: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(2) # Need this because of the starting delay
     darwin_configure(CONF_FTEST_WRONG_CONF, path=PATH_CONF_FTEST)
     resp = requests(REQ_UPDATE_TWO)
     if RESP_STATUS_KO not in resp:
-        logging.error("one_update_one_wrong_conf: Update response error; got \"{}\"".format(resp))
+        logging.error("one_update_one_wrong_filter_conf: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_update_one_wrong_filter_conf: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     if not check_filter_files("test_2", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("one_update_one_wrong_filter_conf: filter files check failed")
         ret = False
 
     if not check_filter_files("test_3", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("one_update_one_wrong_filter_conf: filter files check failed")
         ret = False
 
     darwin_stop(process)
@@ -783,7 +821,7 @@ def many_update_two_wrong_conf():
     return ret
 
 
-def many_update_two_wrong_conf_conf_v2():
+def many_update_two_wrong_filter_conf_v2():
 
     ret = True
 
@@ -793,27 +831,27 @@ def many_update_two_wrong_conf_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_two_wrong_filter_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(2) # Need this because of the starting delay
     darwin_configure(CONF_FTEST_WRONG_CONF, path=PATH_CONF_FTEST)
     resp = requests(REQ_UPDATE_TWO)
     if RESP_STATUS_KO not in resp:
-        logging.error("one_update_one_wrong_conf: Update response error; got \"{}\"".format(resp))
+        logging.error("many_update_two_wrong_filter_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_two_wrong_filter_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     if not check_filter_files("test_2", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("many_update_two_wrong_filter_conf_v2: filter files check failed")
         ret = False
 
     if not check_filter_files("test_3", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("many_update_two_wrong_filter_conf_v2: filter files check failed")
         ret = False
 
     darwin_stop(process)
@@ -822,7 +860,7 @@ def many_update_two_wrong_conf_conf_v2():
     return ret
 
 
-def many_update_all_wrong_conf():
+def many_update_all_wrong_filter_conf():
 
     ret = True
 
@@ -832,31 +870,31 @@ def many_update_all_wrong_conf():
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_all_wrong_filter_conf: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(2) # Need this because of the starting delay
     darwin_configure(CONF_FTEST_WRONG_CONF, path=PATH_CONF_FTEST)
     resp = requests(REQ_UPDATE_THREE)
     if RESP_STATUS_KO not in resp:
-        logging.error("one_update_one_wrong_conf: Update response error; got \"{}\"".format(resp))
+        logging.error("many_update_all_wrong_filter_conf: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_all_wrong_filter_conf: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     if not check_filter_files("test_1", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("many_update_all_wrong_filter_conf: filter files check failed")
         ret = False
 
     if not check_filter_files("test_2", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("many_update_all_wrong_filter_conf: filter files check failed")
         ret = False
 
     if not check_filter_files("test_3", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("many_update_all_wrong_filter_conf: filter files check failed")
         ret = False
 
     darwin_stop(process)
@@ -865,7 +903,7 @@ def many_update_all_wrong_conf():
     return ret
 
 
-def many_update_all_wrong_conf_conf_v2():
+def many_update_all_wrong_filter_conf_v2():
 
     ret = True
 
@@ -875,31 +913,31 @@ def many_update_all_wrong_conf_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_all_wrong_filter_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(2) # Need this because of the starting delay
     darwin_configure(CONF_FTEST_WRONG_CONF, path=PATH_CONF_FTEST)
     resp = requests(REQ_UPDATE_THREE)
     if RESP_STATUS_KO not in resp:
-        logging.error("one_update_one_wrong_conf: Update response error; got \"{}\"".format(resp))
+        logging.error("many_update_all_wrong_filter_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_all_wrong_filter_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     if not check_filter_files("test_1", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("many_update_all_wrong_filter_conf_v2: filter files check failed")
         ret = False
 
     if not check_filter_files("test_2", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("many_update_all_wrong_filter_conf_v2: filter files check failed")
         ret = False
 
     if not check_filter_files("test_3", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("many_update_all_wrong_filter_conf_v2: filter files check failed")
         ret = False
 
     darwin_stop(process)
@@ -948,18 +986,18 @@ def many_update_all_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("many_update_all: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_all_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(1) # Need this because of the starting delay
     resp = requests(REQ_UPDATE_THREE)
     if RESP_STATUS_OK not in resp:
-        logging.error("many_update_all: Update response error; got \"{}\"".format(resp))
+        logging.error("many_update_all_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("many_update_all: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_all_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -1008,18 +1046,18 @@ def non_existing_filter_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("non_existing_filter: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("non_existing_filter_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(1) # Need this because of the starting delay
     resp = requests(REQ_UPDATE_NON_EXISTING)
     if RESP_ERROR_FILTER_NOT_EXISTING not in resp:
-        logging.error("non_existing_filter: Update response error; got \"{}\"".format(resp))
+        logging.error("non_existing_filter_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("non_existing_filter: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("non_existing_filter_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -1151,6 +1189,220 @@ def many_update_diff_one_more_one_less_v2():
 
     if RESP_TEST_3 in resp:
         logging.error('many_update_diff_one_more_one_less_v2: Wrong filter in monitor response; got "{}"'.format(resp))
+        ret = False
+
+    darwin_stop(process)
+    darwin_remove_configuration()
+    darwin_remove_configuration(path=PATH_CONF_FTEST)
+    return ret
+
+
+def one_update_one_wrong_manager_conf():
+
+    ret = True
+
+    darwin_configure(CONF_ONE)
+    darwin_configure(CONF_FTEST, path=PATH_CONF_FTEST)
+    process = darwin_start()
+
+    resp = requests(REQ_MONITOR)
+    if RESP_TEST_1 not in resp:
+        logging.error("one_update_one_wrong_manager_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        ret = False
+
+    sleep(2) # Need this because of the starting delay
+    # add test at the end to invalidate configuration file json
+    darwin_configure(CONF_ONE + "Hello There")
+    resp = requests(REQ_UPDATE_ONE)
+    if RESP_STATUS_KO not in resp:
+        logging.error("one_update_one_wrong_manager_conf: Update response error; got \"{}\"".format(resp))
+        ret = False
+
+    resp = requests(REQ_MONITOR)
+    if RESP_TEST_1 not in resp:
+        logging.error("one_update_one_wrong_manager_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        ret = False
+
+    if not check_filter_files("test_1", ".1"):
+        logging.error("one_update_one_wrong_manager_conf: filter files check failed")
+        ret = False
+
+    darwin_stop(process)
+    darwin_remove_configuration()
+    darwin_remove_configuration(path=PATH_CONF_FTEST)
+    return ret
+
+
+def one_update_one_wrong_manager_conf_v2():
+
+    ret = True
+
+    darwin_configure(CONF_ONE_V2)
+    darwin_configure(CONF_FTEST, path=PATH_CONF_FTEST)
+    process = darwin_start()
+
+    resp = requests(REQ_MONITOR)
+    if RESP_TEST_1 not in resp:
+        logging.error("one_update_one_wrong_manager_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
+        ret = False
+
+    sleep(2) # Need this because of the starting delay
+    # add test at the end to invalidate configuration file json
+    darwin_configure(CONF_ONE_V2 + "Mystere au chocolat")
+    resp = requests(REQ_UPDATE_ONE)
+    if RESP_STATUS_KO not in resp:
+        logging.error("one_update_one_wrong_manager_conf_v2: Update response error; got \"{}\"".format(resp))
+        ret = False
+
+    resp = requests(REQ_MONITOR)
+    if RESP_TEST_1 not in resp:
+        logging.error("one_update_one_wrong_manager_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
+        ret = False
+
+    if not check_filter_files("test_1", ".1"):
+        logging.error("one_update_one_wrong_manager_conf_v2: filter files check failed")
+        ret = False
+
+    darwin_stop(process)
+    darwin_remove_configuration()
+    darwin_remove_configuration(path=PATH_CONF_FTEST)
+    return ret
+
+
+def many_update_all_wrong_manager_conf():
+
+    ret = True
+
+    darwin_configure(CONF_THREE)
+    darwin_configure(CONF_FTEST, path=PATH_CONF_FTEST)
+    process = darwin_start()
+
+    resp = requests(REQ_MONITOR)
+    if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
+        logging.error("one_update_one_wrong_manager_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        ret = False
+
+    sleep(2) # Need this because of the starting delay
+    # add test at the end to invalidate configuration file json
+    darwin_configure(CONF_THREE + "more is not always good")
+    resp = requests(REQ_UPDATE_THREE)
+    if RESP_STATUS_KO not in resp:
+        logging.error("one_update_one_wrong_manager_conf: Update response error; got \"{}\"".format(resp))
+        ret = False
+
+    resp = requests(REQ_MONITOR)
+    if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
+        logging.error("one_update_one_wrong_manager_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        ret = False
+
+    if not check_filter_files("test_1", ".1"):
+        logging.error("one_update_one_wrong_manager_conf: filter files check failed")
+        ret = False
+
+    if not check_filter_files("test_2", ".1"):
+        logging.error("one_update_one_wrong_manager_conf: filter files check failed")
+        ret = False
+
+    if not check_filter_files("test_3", ".1"):
+        logging.error("one_update_one_wrong_manager_conf: filter files check failed")
+        ret = False
+
+    darwin_stop(process)
+    darwin_remove_configuration()
+    darwin_remove_configuration(path=PATH_CONF_FTEST)
+    return ret
+
+
+def many_update_all_wrong_manager_conf_v2():
+
+    ret = True
+
+    darwin_configure(CONF_THREE_V2)
+    darwin_configure(CONF_FTEST, path=PATH_CONF_FTEST)
+    process = darwin_start()
+
+    resp = requests(REQ_MONITOR)
+    if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
+        logging.error("many_update_all_wrong_manager_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
+        ret = False
+
+    sleep(2) # Need this because of the starting delay
+    # add test at the end to invalidate configuration file json
+    darwin_configure(CONF_THREE_V2 + "}")
+    resp = requests(REQ_UPDATE_THREE)
+    if RESP_STATUS_KO not in resp:
+        logging.error("many_update_all_wrong_manager_conf_v2: Update response error; got \"{}\"".format(resp))
+        ret = False
+
+    resp = requests(REQ_MONITOR)
+    if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
+        logging.error("many_update_all_wrong_manager_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
+        ret = False
+
+    if not check_filter_files("test_1", ".1"):
+        logging.error("many_update_all_wrong_manager_conf_v2: filter files check failed")
+        ret = False
+
+    if not check_filter_files("test_2", ".1"):
+        logging.error("many_update_all_wrong_manager_conf_v2: filter files check failed")
+        ret = False
+
+    if not check_filter_files("test_3", ".1"):
+        logging.error("many_update_all_wrong_manager_conf_v2: filter files check failed")
+        ret = False
+
+    darwin_stop(process)
+    darwin_remove_configuration()
+    darwin_remove_configuration(path=PATH_CONF_FTEST)
+    return ret
+
+def many_update_two_less_wrong_then_good_manager_conf():
+
+    ret = True
+
+    darwin_configure(CONF_THREE)
+    darwin_configure(CONF_FTEST, path=PATH_CONF_FTEST)
+    process = darwin_start()
+
+    resp = requests(REQ_MONITOR)
+    if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
+        logging.error("many_update_two_less_wrong_then_good_manager_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        ret = False
+
+    sleep(2) # Need this because of the starting delay
+    # add test at the end to invalidate configuration file json
+    darwin_configure(CONF_THREE + "}")
+    resp = requests(REQ_UPDATE_EMPTY)
+    if RESP_STATUS_KO not in resp:
+        logging.error("many_update_two_less_wrong_then_good_manager_conf: Update response error; got \"{}\"".format(resp))
+        ret = False
+
+    resp = requests(REQ_MONITOR)
+    if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
+        logging.error("many_update_two_less_wrong_then_good_manager_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        ret = False
+
+    darwin_configure(CONF_ONE)
+    resp = requests(REQ_UPDATE_EMPTY)
+    if RESP_STATUS_OK not in resp:
+        logging.error("many_update_two_less_wrong_then_good_manager_conf: expected OK but got \"{}\"".format(resp))
+        ret = False
+
+    resp = requests(REQ_MONITOR)
+    if not all(x in resp for x in [RESP_TEST_1]):
+        logging.error("many_update_two_less_wrong_then_good_manager_conf: Expected one running filter but got \"{}\"".format(resp))
+        ret = False
+
+    if not check_filter_files("test_1", ".1"):
+        logging.error("many_update_two_less_wrong_then_good_manager_conf: filter files check failed")
+        ret = False
+
+    if check_filter_files("test_2", ".1"):
+        logging.error("many_update_two_less_wrong_then_good_manager_conf: filter files check failed")
+        ret = False
+
+    if check_filter_files("test_3", ".1"):
+        logging.error("many_update_two_less_wrong_then_good_manager_conf: filter files check failed")
         ret = False
 
     darwin_stop(process)

--- a/tests/tools/darwin_utils.py
+++ b/tests/tools/darwin_utils.py
@@ -1,17 +1,17 @@
 import subprocess
 import os
 from time import sleep
-from conf import DEFAULT_MANAGER_PATH, DEFAULT_CONFIGURATION_PATH, DEFAULT_PYTHON_EXEC
+from conf import DEFAULT_MANAGER_PATH, DEFAULT_PYTHON_EXEC, TEST_FILES_DIR
 
 
-def darwin_start(darwin_manager_path=DEFAULT_MANAGER_PATH, config_path=DEFAULT_CONFIGURATION_PATH):
+def darwin_start(darwin_manager_path=DEFAULT_MANAGER_PATH, config_path="{}/darwin.conf".format(TEST_FILES_DIR)):
     process = subprocess.Popen([
         DEFAULT_PYTHON_EXEC,
         darwin_manager_path,
         '-l',
         'DEBUG',
         '-p',
-        '/tmp',
+        TEST_FILES_DIR,
         '--no-suffix-directories',
         config_path
     ])
@@ -23,9 +23,9 @@ def darwin_stop(process):
     process.terminate()
     process.wait()
 
-def darwin_configure(conf, path=DEFAULT_CONFIGURATION_PATH):
+def darwin_configure(conf, path="{}/darwin.conf".format(TEST_FILES_DIR)):
     with open(path, mode='w') as file:
         file.write(conf)
 
-def darwin_remove_configuration(path=DEFAULT_CONFIGURATION_PATH):
+def darwin_remove_configuration(path="{}/darwin.conf".format(TEST_FILES_DIR)):
     os.remove(path)


### PR DESCRIPTION
# :sparkles: Avoid Manager crashing when updating a configuration with syntax errors
:bangbang: Once all the **checklist** is **done** you have to:
  * **stash merge** this pull request
  * **delete** the corresponding **branch**
  * **close** the associated **issue**

## :page_with_curl: Type of change

Please delete options that are not relevant.

**Bug fix**: non-breaking change which fixes an issue.

## :bulb: Related Issue(s)

- Resolve #211 

## :black_nib: Description

### MANAGER
- handle exceptions correctly when parsing manager conf file, especially for json formatting

### TESTS
- add tests to manager with wrong json format in manager conf file
- remove MANAGER_SOCKET_PATH, FILTER_SOCKETS_DIR, FILTER_PIDS_DIR and DEFAULT_CONFIGURATION_PATH
- put a single parameter TEST_FILES_DIR instead to set as root for all temporary files during tests (missing darwin.log)

## :dart: Test Environments

### HardenedBSD (12.2)
- Redis (6.0.10)
- Python (3.7.9)

### Ubuntu (18.04)
- Redis (4.0.9)
- Python (3.6.9)

## :heavy_check_mark: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] (**If other changes**) I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

</br>

- [x] :raising_hand: **I certify on my honor that all the information provided is true, and I've done all I can to deliver a high quality code**
