### PR TITLE
Version 1.5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docs"]
+	path = docs
+	url = https://github.com/VultureProject/darwin.wiki

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ else ()
     SET(CMAKE_CXX_FLAGS "-W -Wall -Wextra -o2")
 endif ()
 
+if (COVERAGE)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
+endif()
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 
 if (NOT DEFINED FILTER)
@@ -155,4 +159,12 @@ endif()
 
 if("YARA" IN_LIST FILTERS)
 include(fyara)
+endif()
+
+if("VAST" IN_LIST FILTERS)
+include(fvast)
+endif()
+
+if("VAML" IN_LIST FILTERS)
+include(fvaml)
 endif()

--- a/cmake/fbuffer.cmake
+++ b/cmake/fbuffer.cmake
@@ -18,6 +18,7 @@ add_executable(
     samples/fbuffer/Connectors/AConnector.cpp samples/fbuffer/Connectors/AConnector.hpp
     samples/fbuffer/Connectors/fAnomalyConnector.cpp samples/fbuffer/Connectors/fAnomalyConnector.hpp
     samples/fbuffer/Connectors/fSofaConnector.cpp samples/fbuffer/Connectors/fSofaConnector.hpp
+    samples/fbuffer/Connectors/SumConnector.cpp samples/fbuffer/Connectors/SumConnector.hpp
     samples/fbuffer/OutputConfig.cpp samples/fbuffer/OutputConfig.hpp
     toolkit/AThreadManager.cpp toolkit/AThreadManager.hpp
     toolkit/AThread.cpp toolkit/AThread.hpp

--- a/docker/darwin
+++ b/docker/darwin
@@ -35,7 +35,7 @@ RUN BOOST_UNDERSCORE_VERSION=`echo ${BOOST_VERSION} | tr . _` \
  && mkdir boost \
  && tar xvf boost_${BOOST_UNDERSCORE_VERSION}.tar.gz -C boost --strip-components 1 \
  && cd boost \
- && ./bootstrap.sh --with-libraries="math,program_options,serialization,system,test" --prefix=./install  \
+ && ./bootstrap.sh --with-libraries="math,program_options,serialization,system,test,date_time" --prefix=./install  \
  && ./b2 install
 
 

--- a/manager/Administration.py
+++ b/manager/Administration.py
@@ -6,6 +6,7 @@ __maintainer__ = "Vulture Project"
 __email__ = "contact@vultureproject.org"
 __doc__ = 'The unix socket administration server class'
 
+import datetime
 import socket
 import logging
 import redis
@@ -188,7 +189,9 @@ class Server:
                 if not self._continue:
                     logger.debug("Reporter: stopping")
                     break
-                stats = json.dumps(services.monitor_all())
+                jsonStats = services.monitor_all()
+                jsonStats['timestamp'] = datetime.datetime.utcnow().strftime("%FT%TZ")
+                stats = json.dumps(jsonStats)
                 logger.debug("reporting stats: {}".format(stats))
 
                 if self._stats_redis:

--- a/manager/Services.py
+++ b/manager/Services.py
@@ -322,10 +322,9 @@ class Services:
         try:
             #Reload conf, global variable 'conf_filters' will be updated
             load_conf(prefix, suffix)
-        except ConfParseError:
-            error = "Update: wrong configuration format, unable to update"
-            logger.error(error)
-            return error
+        except ConfParseError as e:
+            logger.error("Update: Unable to update: {}".format(e))
+            return [str(e)]
 
         logger.info("Update: Configuration loaded")
 

--- a/manager/config.py
+++ b/manager/config.py
@@ -233,14 +233,14 @@ def load_conf(prefix, suffix, conf=""):
             configuration = json.load(f)
     except Exception as e:
         logger.critical("Configurator: Unable to load configuration: {}".format(e))
-        raise e
+        raise ConfParseError("Incorrect configuration format: {}".format(e))
 
     if configuration.get('version'):
         logger.debug("Configurator: found a 'version' field, trying v2 format...")
         try:
             custom_validator(conf_v2_schema).validate(configuration)
         except Exception as e:
-            raise ConfParseError("Incorrect configuration format: {}".format(e.message))
+            raise ConfParseError("Incorrect configuration format: {}".format(e))
         filters.clear()
         stats_reporting.clear()
         stats_reporting.update(configuration['report_stats'])
@@ -252,7 +252,7 @@ def load_conf(prefix, suffix, conf=""):
         try:
             custom_validator(conf_v1_schema).validate(configuration)
         except Exception as e:
-            raise ConfParseError("Incorrect configuration format: {}".format(e.message))
+            raise ConfParseError("Incorrect configuration format: {}".format(e))
         stats_reporting.clear()
         filters.clear()
         filters.update(configuration)

--- a/samples/base/AlertManager.cpp
+++ b/samples/base/AlertManager.cpp
@@ -6,6 +6,7 @@
 /// \brief    Copyright (c) 2019 Advens. All rights reserved.
 
 #include <sstream>
+#include <iomanip>
 #include "Logger.hpp"
 #include "AlertManager.hpp"
 #include "Time.hpp"
@@ -201,7 +202,7 @@ namespace darwin {
         else
             ss << "\"tags\": " << tags << ", ";
 
-        ss << "\"entry\": \"" << entry << "\", ";
+        ss << "\"entry\": " << std::quoted(entry, '"', '\\') << ", ";
         ss << "\"score\": "  << certitude << ", ";
         ss << "\"evt_id\": \"" << evt_id << "\", ";
         ss << "\"details\": ";

--- a/samples/base/Core.cpp
+++ b/samples/base/Core.cpp
@@ -48,8 +48,11 @@ namespace darwin {
 
             try {
                 Server server{_socketPath, _output, _nextFilterUnixSocketPath, _threshold, gen};
-                if (not gen.ConfigureNetworkObject(server.GetIOContext()))
+                if (not gen.ConfigureNetworkObject(server.GetIOContext())) {
+                    raise(SIGTERM);
+                    t.join();
                     return 1;
+                }
                 SET_FILTER_STATUS(darwin::stats::FilterStatusEnum::running);
 
                 DARWIN_LOG_DEBUG("Core::run:: Creating threads...");

--- a/samples/fbuffer/BufferTask.cpp
+++ b/samples/fbuffer/BufferTask.cpp
@@ -105,6 +105,13 @@ bool BufferTask::ParseData(rapidjson::Value &data, darwin::valueType input_type)
             }
             this->_data = std::to_string(data.GetInt64());
             break;
+        case darwin::FLOAT:
+            if (not data.IsDouble() and not data.IsInt64()) {
+                DARWIN_LOG_ERROR("BufferTask::ParseData: The value sent must be a decimal");
+                return false;
+            }
+            this->_data = std::to_string(data.GetDouble());
+            break;
         default:
             return false;
     }

--- a/samples/fbuffer/BufferTask.cpp
+++ b/samples/fbuffer/BufferTask.cpp
@@ -41,7 +41,6 @@ void BufferTask::operator()() {
     for (rapidjson::Value &line : array) {
         STAT_INPUT_INC;
         if (ParseLine(line)) {
-            STAT_MATCH_INC;
             this->_certitudes.push_back(0);
             this->AddEntries();
         } else {

--- a/samples/fbuffer/BufferThread.cpp
+++ b/samples/fbuffer/BufferThread.cpp
@@ -33,7 +33,7 @@ bool BufferThread::Main() {
             DARWIN_LOG_DEBUG("BufferThread::Main:: Not enough log in Redis, wait for more");
             continue;
         } else if (len<0 || !this->_connector->REDISPopLogs(len, logs, redis_list)) {
-            DARWIN_LOG_ERROR("BufferThread::Main:: Error when querying Redis on list: " + redis_list + " for source: " + redis_config.first);
+            DARWIN_LOG_ERROR("BufferThread::Main:: Error when querying Redis on list: " + redis_list + " for source: '" + redis_config.first + "'");
             continue;
         } else {
             if (not _connector->SendToFilter(logs)) {

--- a/samples/fbuffer/Connectors/AConnector.hpp
+++ b/samples/fbuffer/Connectors/AConnector.hpp
@@ -61,6 +61,13 @@ class AConnector {
     ///\return this->_redis_lists
     std::vector<std::pair<std::string, std::string>> GetRedisLists() const;
 
+    ///\brief test every Redis Key in _redis_lists to see if they can be used in REdis
+    /// if keys exist and are of the correct type, they are deleted to be reset
+    /// if a key is not the correct type, it is assumed it's already used for another application and filter will fail
+    ///
+    ///\return true if the keys are not in redis, or are of a correct type, false otherwise.
+    virtual bool PrepareKeysInRedis();
+
     ///\brief Virtual function that can be overrode if needed. Used to add an entry in the Redis storage set list_name.
     ///
     /// It can be overrode by children if they need another type of REDIS storage. 

--- a/samples/fbuffer/Connectors/Connectors.hpp
+++ b/samples/fbuffer/Connectors/Connectors.hpp
@@ -13,3 +13,4 @@
 // Subclasses
 #include "fAnomalyConnector.hpp"
 #include "fSofaConnector.hpp"
+#include "SumConnector.hpp"

--- a/samples/fbuffer/Connectors/SumConnector.cpp
+++ b/samples/fbuffer/Connectors/SumConnector.cpp
@@ -1,0 +1,181 @@
+/// \file     SumConnector.cpp
+/// \authors  Theo Bertin
+/// \version  1.0
+/// \date     15/12/20
+/// \license  GPLv3
+/// \brief    Copyright (c) 2018 Advens. All rights reserved.
+
+#include <algorithm>    //std::min
+
+#include "../../../toolkit/RedisManager.hpp"
+
+#include "SumConnector.hpp"
+#include "Time.hpp"
+
+SumConnector::SumConnector(boost::asio::io_context &context, std::string &filter_socket_path, unsigned int interval, std::vector<std::pair<std::string, std::string>> &redis_lists, unsigned int minLogLen) :
+                    AConnector(context, darwin::SUM, filter_socket_path, interval, redis_lists, minLogLen) {}
+
+
+bool SumConnector::ParseInputForRedis(std::map<std::string, std::string> &input_line) {
+    this->_input_line = input_line;
+    this->_entry.clear();
+
+    std::string source = this->GetSource();
+
+    if (not this->ParseData("decimal"))
+        return false;
+
+    for (const auto &redis_config : this->_redis_lists) {
+        // If the source in the input is equal to the source in the redis list, or the redis list's source is empty
+        if (not redis_config.first.compare(source) or redis_config.first.empty())
+                this->REDISAddEntry(this->_entry, redis_config.second);
+    }
+    return true;
+}
+
+
+bool SumConnector::PrepareKeysInRedis(){
+    DARWIN_LOGGER;
+    std::string redis_list, reply;
+    bool ret = true;
+
+    darwin::toolkit::RedisManager& redis = darwin::toolkit::RedisManager::GetInstance();
+
+    for(auto key : this->_redis_lists) {
+        redis_list = key.second;
+        DARWIN_LOG_DEBUG("SumConnector::PrepareKeysInRedis:: testing key " + redis_list);
+        if(redis.Query(std::vector<std::string>{"TYPE", redis_list}, reply, true) != REDIS_REPLY_STATUS) {
+            DARWIN_LOG_ERROR("SumConnector::PrepareKeysInRedis:: Could not get current type of key");
+            ret = false;
+            continue;
+        }
+
+        DARWIN_LOG_DEBUG("SumConnector::PrepareKeysInRedis:: key '"+ redis_list + "' is '" + reply + "'");
+
+        if(reply != "none") {
+            if(reply != "string") {
+                DARWIN_LOG_ERROR("SumConnector::PrepareKeysInRedis:: key '" + redis_list + "' is already present but seems"
+                                " to be used by something else, cannot start the filter "
+                                "and risk overriding data in Redis");
+                ret = false;
+                continue;
+            }
+
+            DARWIN_LOG_WARNING("SumConnector::PrepareKeysInRedis:: The key '" + redis_list + "' was already set in Redis, "
+                                "the key will be overrode!");
+
+            DARWIN_LOG_DEBUG("SumConnector::PrepareKeysInRedis:: reseting Redis key '" + redis_list + "'");
+            if(redis.Query(std::vector<std::string>{"DEL", redis_list}) != REDIS_REPLY_INTEGER) {
+                DARWIN_LOG_WARNING("SumConnector::PrepareKeysInRedis:: could not reset the key");
+            }
+        }
+    }
+
+    return ret;
+}
+
+
+bool SumConnector::REDISAddEntry(const std::string &entry, const std::string &sum_name) {
+    DARWIN_LOGGER;
+    DARWIN_LOG_DEBUG("SumConnector::REDISAddEntry:: Incrementing sum in Redis...");
+
+    darwin::toolkit::RedisManager& redis = darwin::toolkit::RedisManager::GetInstance();
+
+    std::vector<std::string> arguments;
+    arguments.clear();
+    arguments.emplace_back("INCRBYFLOAT");
+    arguments.emplace_back(sum_name);
+    arguments.emplace_back(entry);
+
+    if(redis.Query(arguments, true) != REDIS_REPLY_STRING) {
+        DARWIN_LOG_ERROR("SumConnector::REDISAddEntry:: Not the expected Redis response, impossible to increment redis key " + sum_name);
+        DARWIN_LOG_DEBUG("SumConnector::REDISAddEntry:: entry was " + entry);
+        return false;
+    }
+    return true;
+}
+
+
+bool SumConnector::REDISReinsertLogs(std::vector<std::string> &logs __attribute__((unused)), const std::string &sum_name __attribute__((unused))) {
+    DARWIN_LOGGER;
+    DARWIN_LOG_WARNING("SumConnector::REDISReinsertLogs:: Will not reinsert logs, data lost");
+    return true;
+}
+
+
+bool SumConnector::REDISPopLogs(long long int len __attribute__((unused)), std::vector<std::string> &logs, const std::string &sum_name) noexcept {
+    DARWIN_LOGGER;
+    DARWIN_LOG_DEBUG("SumConnector::REDISPopLogs:: Querying Redis for sum key...");
+
+    int redis_reply;
+    std::any result;
+    std::string result_string;
+
+    darwin::toolkit::RedisManager& redis = darwin::toolkit::RedisManager::GetInstance();
+
+    redis_reply = redis.Query(std::vector<std::string>{"GETSET", sum_name, "0"}, result, true);
+    if (redis_reply == REDIS_REPLY_NIL) {
+        DARWIN_LOG_INFO("SumConnector:: REDISPopLogs:: key '" + sum_name + "' does not exist (yet?)");
+        return false;
+    }
+    else if(redis_reply != REDIS_REPLY_STRING) {
+        DARWIN_LOG_ERROR("SumConnector::REDISPopLogs:: Not the expected Redis response");
+        return false;
+    }
+
+    try {
+        result_string = std::any_cast<std::string>(result);
+    }
+    catch (const std::bad_any_cast&) {
+        DARWIN_LOG_ERROR("SumConnector:REDISPopLogs:: Impossible to cast redis response into a string.");
+        return false;
+    }
+
+    DARWIN_LOG_DEBUG("SumConnector::REDISPopLogs:: Got '" + result_string + "' from Redis");
+
+    logs.emplace_back(result_string);
+
+    return true;
+}
+
+
+long long int SumConnector::REDISListLen(const std::string &sum_name) noexcept {
+    DARWIN_LOGGER;
+    DARWIN_LOG_DEBUG("SumConnector::REDISListLen:: Querying Redis for sum size...");
+
+    std::string result_string;
+    long double result = 0.0L;
+    int redis_reply;
+
+    darwin::toolkit::RedisManager& redis = darwin::toolkit::RedisManager::GetInstance();
+
+    redis_reply = redis.Query(std::vector<std::string>{"GET", sum_name}, result_string, true);
+    if (redis_reply == REDIS_REPLY_NIL) {
+        DARWIN_LOG_INFO("SumConnector::REDISListLen:: key '" + sum_name + "' does not exist (yet?)");
+    }
+    else if (redis_reply == REDIS_REPLY_STRING) {
+        result = strtold(result_string.c_str(), NULL);
+        // Error while parsing integer
+        if(errno == ERANGE) {
+            DARWIN_LOG_ERROR("SumConnector::REDISListLen:: overflow/underflow while trying to parse value");
+            result = 0.0L;
+        }
+    }
+    else {
+        DARWIN_LOG_ERROR("SumConnector::REDISListLen:: Error while querying key '" + sum_name + "'");
+        result = 0.0L;
+    }
+
+    // Return an absolute rounded value for the double, cap with the maximum value of a long long int
+    return (long long int)std::min(std::abs(std::round(result)), (long double)std::numeric_limits<long long int>::max());
+}
+
+
+bool SumConnector::FormatDataToSendToFilter(std::vector<std::string> &logs, std::string &res) {
+    res.clear();
+    if(logs.size() == 1) {
+        res = "[[" + logs[0] + ",\"" + darwin::time_utils::GetTime() + "\"" + "]]";
+    }
+
+    return not res.empty();
+}

--- a/samples/fbuffer/Connectors/SumConnector.hpp
+++ b/samples/fbuffer/Connectors/SumConnector.hpp
@@ -1,0 +1,89 @@
+/// \file     SumConnector.cpp
+/// \authors  Theo Bertin
+/// \version  1.0
+/// \date     15/12/20
+/// \license  GPLv3
+/// \brief    Copyright (c) 2018 Advens. All rights reserved.
+
+#pragma once
+
+#include "AConnector.hpp"
+
+class SumConnector final : public AConnector {
+    /// This class inherits from AConnector (see AConnector.hpp)
+    /// It provides cumulative incrementation of a value
+    ///
+    ///\class SumConnector
+
+public:
+    ///\brief Unique constructor.
+    ///
+    ///\param io_context The boost::asio::io_context used by the Server. Needed for communication with output Filter.
+    ///\param filter_socket_path The socket path used to connect to the output filter.
+    ///\param interval Interval between two data sendings to output filter.
+    ///\param redis_lists The names of the Redis List on which the connector will store and retrieve data depending on source, before sending to output Filter
+    ///\param required_log_lines The number of logs required before sending data to output Filter
+    SumConnector(boost::asio::io_context &context,
+                    std::string &filter_socket_path,
+                    unsigned int interval,
+                    std::vector<std::pair<std::string, std::string>> &redis_lists,
+                    unsigned int required_log_lines);
+
+    ///\brief Virtual final default constructor
+    virtual ~SumConnector() override final = default;
+
+    ///\brief test every Redis Key in _redis_lists to ensure keys are of the correct type if they exist in Redis
+    ///
+    ///\return true if the keys are not in redis, or are of the good type, false otherwise.
+    virtual bool PrepareKeysInRedis();
+
+    ///\brief This function sends data to the REDIS storage. It overrides default pure virtual one as each filter doesn't need the same data.
+    ///
+    /// It should fill _entry with the data to send as REDISAddEntry is picking from it.
+    ///
+    ///\param input_line is a map representing all the entries received by the BufferTask.
+    ///
+    ///\return true on success, false otherwise.
+    virtual bool ParseInputForRedis(std::map<std::string, std::string> &input_line) override final;
+
+    ///\brief Increment sum by the amount given
+    ///
+    ///\param entry The amount with which to increment the sum.
+    ///\param sum_name The name of the sum in Redis.
+    ///
+    ///\return true on success, false otherwise.
+    virtual bool REDISAddEntry(const std::string &entry, const std::string &sum_name) override final;
+
+    ///\brief Overrided function. This function does nothing, as reinsertion is detrimentakl to normal detection
+    ///
+    ///\param logs unused parameter
+    ///\param sum_name unused parameter
+    ///
+    ///\return always true
+    virtual bool REDISReinsertLogs(std::vector<std::string> &logs __attribute__((unused)), const std::string &sum_name __attribute__((unused)));
+
+    ///\brief Get the sum from Redis
+    ///
+    /// \param len The number of elements to pick up in the list (unused, for compatibility with format handled by BufferThread)
+    /// \param logs The vector used to store our log
+    /// \param sum_name The name of the sum in Redis
+    ///
+    /// \return true on success, false otherwise.
+    virtual bool REDISPopLogs(long long int len __attribute__((unused)), std::vector<std::string> &logs, const std::string &sum_name) noexcept override final;
+
+    ///\brief Override default REDISListLen to check if sum was incremented at least once.
+    ///
+    /// \param sum_name The name of the sum to check
+    ///
+    /// \return 0 if the sum is null, 1 if the sum is not null, -1 in case of error
+    virtual long long int REDISListLen(const std::string &sum_name) noexcept override final;
+
+protected:
+    ///\brief Overrode to generate a simple list (instead of double list, useless here)
+    ///
+    ///\param count The sum to jsonify
+    ///\param format The string to fill with the result
+    ///
+    ///\return True on success (formatting successful), False otherwise.
+    virtual bool FormatDataToSendToFilter(std::vector<std::string> &logs, std::string &formatted);
+};

--- a/samples/fbuffer/enums.hpp
+++ b/samples/fbuffer/enums.hpp
@@ -11,12 +11,14 @@ namespace darwin {
     typedef enum valueType_e {
         STRING = 0,
         INT,
+        FLOAT,
         UNKNOWN_VALUE_TYPE
     } valueType;
     
     typedef enum outputType_e {
         ANOMALY = 0,
         SOFA,
+        SUM,
         UNKNOWN_OUTPUT
     } outputType;
 } // namespace darwin

--- a/samples/ftest/TestTask.cpp
+++ b/samples/ftest/TestTask.cpp
@@ -39,17 +39,17 @@ long TestTask::GetFilterCode() noexcept {
 
 void TestTask::operator()() {
     DARWIN_LOGGER;
-    bool is_log = GetOutputType() == darwin::config::output_type::LOG;
 
     // Should not fail, as the Session body parser MUST check for validity !
     auto array = _body.GetArray();
 
     for (auto &line : array) {
         SetStartingTime();
-        xxh::hash64_t hash;
 
         if(ParseLine(line)) {
+            DARWIN_LOG_DEBUG("TestTask:: parsed line successfully");
             if(_line == "trigger_redis_list") {
+                DARWIN_LOG_DEBUG("TestTask:: triggered redis list action");
                 if(REDISAddList(_redis_list, _line)) {
                     _certitudes.push_back(0);
                 }
@@ -58,6 +58,7 @@ void TestTask::operator()() {
                 }
             }
             else if(_line == "trigger_redis_channel") {
+                DARWIN_LOG_DEBUG("TestTask:: triggered redis channel action");
                 if(REDISPublishChannel(_redis_channel, _line)) {
                     _certitudes.push_back(0);
                 }
@@ -66,6 +67,7 @@ void TestTask::operator()() {
                 }
             }
             else {
+                DARWIN_LOG_DEBUG("TestTask:: not triggered specific action, generating alert by default");
                 DARWIN_ALERT_MANAGER.Alert(_line, 100, Evt_idToString());
                 _certitudes.push_back(0);
             }
@@ -83,7 +85,7 @@ bool TestTask::REDISAddList(const std::string& list, const std::string& line) {
     darwin::toolkit::RedisManager& redis = darwin::toolkit::RedisManager::GetInstance();
 
     if(redis.Query(std::vector<std::string>{"LPUSH", list, line}, true) != REDIS_REPLY_INTEGER) {
-        DARWIN_LOG_WARNING("LogsTask::REDISAddLogs:: Failed to add log in Redis !");
+        DARWIN_LOG_WARNING("TestTask::REDISAddLogs:: Failed to add log in Redis !");
         return false;
     }
 
@@ -97,7 +99,7 @@ bool TestTask::REDISPublishChannel(const std::string& channel, const std::string
     darwin::toolkit::RedisManager& redis = darwin::toolkit::RedisManager::GetInstance();
 
     if(redis.Query(std::vector<std::string>{"PUBLISH", channel, line}, true) != REDIS_REPLY_INTEGER) {
-        DARWIN_LOG_WARNING("LogsTask::REDISAddLogs:: Failed to add log in Redis !");
+        DARWIN_LOG_WARNING("TestTask::REDISAddLogs:: Failed to add log in Redis !");
         return false;
     }
 
@@ -107,24 +109,24 @@ bool TestTask::REDISPublishChannel(const std::string& channel, const std::string
 bool TestTask::ParseLine(rapidjson::Value& line) {
     DARWIN_LOGGER;
 
-    if(not line.IsArray()) {
-        DARWIN_LOG_ERROR("TestTask:: ParseBody: The input line is not an array");
-        return false;
+    _line.clear();
+
+    // Parse objects as string
+    if (line.IsArray() or line.IsObject()) {
+        rapidjson::StringBuffer buffer;
+        rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+
+        line.Accept(writer);
+        _line = std::string(buffer.GetString());
+    }
+    else if (line.IsString()){
+        _line = line.GetString();
+    }
+    else if (line.IsNumber()) {
+        _line = std::to_string(line.GetDouble());
     }
 
-    auto values = line.GetArray();
-
-    if (values.Size() != 1) {
-        DARWIN_LOG_ERROR("TestTask:: ParseBody: You must provide only one value in the list");
-        return false;
-    }
-
-    if (not values[0].IsString()) {
-        DARWIN_LOG_ERROR("TestTask:: ParseBody: The value sent must be a string");
-        return false;
-    }
-
-    _line = values[0].GetString();
+    DARWIN_LOG_DEBUG("TestTask::ParseLine:: line is '" + _line + "'");
 
     if (_line == "trigger_ParseLine_error")
         return false;

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -1,14 +1,10 @@
-# DARWIN FILES
-MANAGEMENT_SOCKET_PATH = '/var/sockets/darwin/darwin.sock'
-FILTER_SOCKETS_DIR = "/var/sockets/darwin/"
-FILTER_PIDS_DIR = "/var/run/darwin/"
-DEFAULT_CONFIGURATION_PATH = '/tmp/darwin.conf'
+# Where all Runtime and temporary files will be put (configurations, sockets, pid files, logging files... except darwin.log)
+TEST_FILES_DIR = '/tmp'
 
 # ENV CONFIG
 PYTHON_ENV_PATH = "/usr/local/lib/python3.7"
 DEFAULT_PYTHON_EXEC = 'python3'
 
-TEST_FILES_DIR = '/tmp'
 DEFAULT_MANAGER_PATH = '/home/darwin/manager/manager.py'
 DEFAULT_FILTER_PATH = '/home/darwin/filters/'
 

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -8,7 +8,7 @@ DEFAULT_CONFIGURATION_PATH = '/tmp/darwin.conf'
 PYTHON_ENV_PATH = "/usr/local/lib/python3.7"
 DEFAULT_PYTHON_EXEC = 'python3'
 
-MOCK_PATH = '/home/darwin/tests/tools/'
+TEST_FILES_DIR = '/tmp'
 DEFAULT_MANAGER_PATH = '/home/darwin/manager/manager.py'
 DEFAULT_FILTER_PATH = '/home/darwin/filters/'
 

--- a/tests/core/redis.py
+++ b/tests/core/redis.py
@@ -54,8 +54,7 @@ def simple_master_server():
         num_list_entries = redis_connection.llen(REDIS_LIST_NAME)
 
     if num_list_entries != 1:
-        logging.error("simple_master_server: wrong number of entries in the redis list {}: " +
-                        "expected 1 but got {}".format(REDIS_LIST_NAME, str(num_list_entries)))
+        logging.error("simple_master_server: wrong number of entries in the redis list {}: expected 1 but got {}".format(REDIS_LIST_NAME, str(num_list_entries)))
         return False
 
     return True

--- a/tests/filters/fbuffer.py
+++ b/tests/filters/fbuffer.py
@@ -1,3 +1,4 @@
+import json
 import os
 import uuid
 import redis
@@ -9,12 +10,12 @@ from tools.redis_utils import RedisServer
 from tools.filter import Filter
 from tools.output import print_result
 from darwin import DarwinApi, DarwinPacket
-from filters.fanomaly import Anomaly
+from filters.ftanomaly import DATA_TEST, EXPECTED_ALERTS
 
 REDIS_SOCKET = "/tmp/redis.sock"
 FILTER_CODE = 0x62756672
-DATA_TEST = "filters/data/anomalyData.txt"
 REDIS_ALERT_LIST = "darwin_buffer_test_alert"
+REDIS_ALERT_CHANNEL = "darwin.buffer.test.alert"
 
 class Buffer(Filter):
     def __init__(self):
@@ -35,7 +36,8 @@ class Buffer(Filter):
                         '{{"name": "os", "type": "string"}},' \
                         '{{"name": "proto", "type": "string"}},' \
                         '{{"name": "port", "type": "string"}},' \
-                        '{{"name": "test_int", "type": "int"}}' \
+                        '{{"name": "test_int", "type": "int"}},' \
+                        '{{"name": "decimal", "type": "float"}}' \
                       '],' \
                       '"outputs": [' \
                         '{{' \
@@ -70,32 +72,6 @@ class Buffer(Filter):
                     '}}'.format(redis_socket=REDIS_SOCKET)
         super().configure(content)
 
-    def get_internal_redis_set_data(self, redis_list_name):
-        res = None
-
-        try:
-            r = redis.Redis(unix_socket_path=self.redis.unix_socket, db=0)
-            res = r.smembers(redis_list_name)
-            r.close()
-        except Exception as e:
-            logging.error("Unable to connect to redis list {redis_list_name}: {error}".format(error=e, redis_list_name=redis_list_name))
-            return None
-
-        return res
-
-    def get_internal_redis_list_data(self, redis_list_name):
-        res = None
-
-        try:
-            r = redis.Redis(unix_socket_path=self.redis.unix_socket, db=0)
-            res = r.lrange(redis_list_name, 0, -1)
-            r.close()
-        except Exception as e:
-            logging.error("Unable to connect to redis list {redis_list_name}: {error}".format(error=e, redis_list_name=redis_list_name))
-            return None
-
-        return res
-
     def get_test_data(self):
         if self.test_data is not None:
             return self.test_data
@@ -115,6 +91,7 @@ def run():
         not_data_list_ignored_test,
         not_data_string_ignored_test,
         not_data_int_ignored_test,
+        not_data_float_ignored_test,
         data_too_short_ignored_test,
         data_too_long_ignored_test,
         multiple_sources_test,
@@ -123,7 +100,12 @@ def run():
         missing_data_in_conf,
         thread_working_test,
         fanomaly_connector_and_send_test,
-        fsofa_connector_test
+        fsofa_connector_test,
+        sum_test_one_value,
+        sum_test_multiple_values,
+        sum_test_not_enough,
+        sum_reset_existing_key,
+        sum_existing_key_other_type
     ]
     for i in tests:
             print_result("buffer: " + i.__name__, i)
@@ -166,7 +148,8 @@ def redis_test(test_name, data, expectations, config=None, bulk=True):
             )
 
     for expect_pair in expectations:
-        redis_data = buffer_filter.get_internal_redis_set_data(expect_pair[0])
+        with buffer_filter.redis.connect() as redis_connection:
+            redis_data = redis_connection.smembers(expect_pair[0])
         expected_data = data_to_bytes(expect_pair[1])
 
         if redis_data!=expected_data:
@@ -187,8 +170,8 @@ def well_formatted_data_test():
     return redis_test(
         "well_formatted_data_test",
         [
-            ["source_1", "net_src_ip_value_1", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_1", 2], # Well formated
-            ["source_1", "net_src_ip_value_2", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_2", 1]  # Well formated
+            ["source_1", "net_src_ip_value_1", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_1", 2, 0.3], # Well formated
+            ["source_1", "net_src_ip_value_2", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_2", 1, 4]  # Well formated
         ],
         [(
             "darwin_buffer_anomaly",
@@ -203,7 +186,7 @@ def not_data_list_ignored_test():
     return redis_test(
         "not_data_list_ignored_test",
         [
-            ["source_1", "net_src_ip_value_1", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_1", 3], # Well formated
+            ["source_1", "net_src_ip_value_1", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_1", 3, 4.2], # Well formated
             "source_1"
         ],
         [(
@@ -218,7 +201,7 @@ def not_data_string_ignored_test():
     return redis_test(
         "not_data_string_ignored_test",
         [
-            ["source_1", "net_src_ip_value__", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_1", 12], # Well formated
+            ["source_1", "net_src_ip_value__", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_1", 12, -32.2], # Well formated
             ["source_1", 42, "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_2"]
         ],
         [(
@@ -233,8 +216,23 @@ def not_data_int_ignored_test():
     return redis_test(
         "not_data_int_ignored_test",
         [
-            ["source_1", "net_src_ip_value_1", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_1", 7], # Well formated
-            ["source_1", "net_src_ip_value_2", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_2", "8"]
+            ["source_1", "net_src_ip_value_1", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_1", 7, 1.2], # Well formated
+            ["source_1", "net_src_ip_value_2", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_2", "8", -4.3]
+        ],
+        [(
+            "darwin_buffer_anomaly",
+            [
+                ["net_src_ip_value_1", "1", "2", "3"]
+            ]
+        )]
+    )
+
+def not_data_float_ignored_test():
+    return redis_test(
+        "not_data_int_ignored_test",
+        [
+            ["source_1", "net_src_ip_value_1", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_1", 7, 1.2], # Well formated
+            ["source_1", "net_src_ip_value_2", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_2", 8, "6.66"]
         ],
         [(
             "darwin_buffer_anomaly",
@@ -248,7 +246,7 @@ def data_too_short_ignored_test():
     return redis_test(
         "data_too_short_ignored_test",
         [
-            ["source_1", "net_src_ip_value_1", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_1", 9], # Well formated
+            ["source_1", "net_src_ip_value_1", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_1", 9, 13.4], # Well formated
             ["source_1", "net_src_ip_value_2", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value"]
         ],
         [(
@@ -263,8 +261,8 @@ def data_too_long_ignored_test():
     return redis_test(
         "data_too_long_ignored_test",
         [
-            ["source_1", "net_src_ip_value__", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_1", 9], # Well formated
-            ["source_1", "net_src_ip_value__", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_2", 10, 12]
+            ["source_1", "net_src_ip_value__", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_1", 9, 12], # Well formated
+            ["source_1", "net_src_ip_value__", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_2", 10, 12, 13]
         ],
         [(
             "darwin_buffer_anomaly",
@@ -278,8 +276,8 @@ def multiple_sources_test():
     return redis_test(
         "multiple_sources_test",
         [
-            ["source_2", "net_src_ip_value_1", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_1", 9], # Well formated
-            ["source_3", "net_src_ip_value_2", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_2", 8]  # Well formated
+            ["source_2", "net_src_ip_value_1", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_1", 9, 4.2], # Well formated
+            ["source_3", "net_src_ip_value_2", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_2", 8, 2.4]  # Well formated
         ],
         [(
             "darwin_buffer_anomaly_2",
@@ -306,8 +304,8 @@ def multiple_outputs_redis_test():
     return redis_test(
         "multiple_outputs_redis_test",
         [
-            ["source_1", "net_src_ip_value_1", "1", "2", "3", "ip_value_1", "hostname_value", "os_value", "proto_value", "port_value_1", 9], # Well formated
-            ["source_2", "net_src_ip_value_2", "1", "2", "3", "ip_value_2", "hostname_value", "os_value", "proto_value", "port_value_2", 8]  # Well formated
+            ["source_1", "net_src_ip_value_1", "1", "2", "3", "ip_value_1", "hostname_value", "os_value", "proto_value", "port_value_1", 9, 6.66], # Well formated
+            ["source_2", "net_src_ip_value_2", "1", "2", "3", "ip_value_2", "hostname_value", "os_value", "proto_value", "port_value_2", 8, 6.66]  # Well formated
         ],
         [(
             "darwin_buffer_anomaly",
@@ -329,26 +327,26 @@ def multiple_inputs_redis_test():
     return redis_test(
         "multiple_inputs_redis_test",
         [
-            ["source_1", "net_src_ip_value_1", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_1", 1],  # Well formated
-            ["source_1", "net_src_ip_value_2", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_2", 2],  # Well formated
-            ["source_1", "net_src_ip_value_3", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_3", 3],  # Well formated
-            ["source_1", "net_src_ip_value_4", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_4", 4],  # Well formated
-            ["source_1", "net_src_ip_value_5", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_5", 5],  # Well formated
-            ["source_1", "net_src_ip_value_6", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_6", 6],  # Well formated
-            ["source_1", "net_src_ip_value_7", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_7", 7],  # Well formated
-            ["source_1", "net_src_ip_value_8", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_8", 8],  # Well formated
-            ["source_1", "net_src_ip_value_9", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 9],  # Well formated
-            ["source_1", "net_src_ip_value_10", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 10], # Well formated
-            ["source_1", "net_src_ip_value_11", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 11], # Well formated
-            ["source_1", "net_src_ip_value_12", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 12], # Well formated
-            ["source_1", "net_src_ip_value_13", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 13], # Well formated
-            ["source_1", "net_src_ip_value_14", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 14], # Well formated
-            ["source_1", "net_src_ip_value_15", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 15], # Well formated
-            ["source_1", "net_src_ip_value_16", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 16], # Well formated
-            ["source_1", "net_src_ip_value_17", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 17], # Well formated
-            ["source_1", "net_src_ip_value_18", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 18], # Well formated
-            ["source_1", "net_src_ip_value_19", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 19], # Well formated
-            ["source_1", "net_src_ip_value_20", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 20]  # Well formated
+            ["source_1", "net_src_ip_value_1", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_1", 1, 10.11],  # Well formated
+            ["source_1", "net_src_ip_value_2", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_2", 2, 10.11],  # Well formated
+            ["source_1", "net_src_ip_value_3", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_3", 3, 10.11],  # Well formated
+            ["source_1", "net_src_ip_value_4", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_4", 4, 10.11],  # Well formated
+            ["source_1", "net_src_ip_value_5", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_5", 5, 10.11],  # Well formated
+            ["source_1", "net_src_ip_value_6", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_6", 6, 10.11],  # Well formated
+            ["source_1", "net_src_ip_value_7", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_7", 7, 10.11],  # Well formated
+            ["source_1", "net_src_ip_value_8", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_8", 8, 10.11],  # Well formated
+            ["source_1", "net_src_ip_value_9", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 9, 10.11],  # Well formated
+            ["source_1", "net_src_ip_value_10", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 10, 13.14], # Well formated
+            ["source_1", "net_src_ip_value_11", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 11, 13.14], # Well formated
+            ["source_1", "net_src_ip_value_12", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 12, 13.14], # Well formated
+            ["source_1", "net_src_ip_value_13", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 13, 13.14], # Well formated
+            ["source_1", "net_src_ip_value_14", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 14, 13.14], # Well formated
+            ["source_1", "net_src_ip_value_15", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 15, 13.14], # Well formated
+            ["source_1", "net_src_ip_value_16", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 16, 13.14], # Well formated
+            ["source_1", "net_src_ip_value_17", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 17, 13.14], # Well formated
+            ["source_1", "net_src_ip_value_18", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 18, 13.14], # Well formated
+            ["source_1", "net_src_ip_value_19", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 19, 13.14], # Well formated
+            ["source_1", "net_src_ip_value_20", "1", "2", "3", "ip_value", "hostname_value", "os_value", "proto_value", "port_value_9", 20, 13.14]  # Well formated
         ],
         [(
             "darwin_buffer_anomaly",
@@ -423,7 +421,7 @@ def thread_working_test():
     if not buffer_filter.valgrind_start():
         return False
 
-    if not test_filter.start():
+    if not test_filter.valgrind_start():
         print("Anomaly did not start")
         return False
 
@@ -441,7 +439,9 @@ def thread_working_test():
     # We wait for the thread to activate
     sleep(15)
 
-    redis_data = buffer_filter.get_internal_redis_set_data("darwin_buffer_anomaly")
+    with buffer_filter.redis.connect() as redis_connection:
+        redis_data = redis_connection.smembers("darwin_buffer_anomaly")
+    # redis_data = buffer_filter.get_internal_redis_set_data("darwin_buffer_anomaly")
 
     if redis_data != set() :
         logging.error("thread_working_test : Expected no data in Redis but got {}".format(redis_data))
@@ -491,6 +491,17 @@ def missing_data_in_conf():
                     '}}'.format(redis_socket=REDIS_SOCKET)
 
     )
+
+
+def format_alert(alert, test_name):
+        res = json.loads(alert)
+        if "alert_time" in res:
+            del res["alert_time"]
+        else:
+            logging.error("{} : No time in the alert : {}.".format(test_name, res))
+        if "evt_id" in res:
+            del res["evt_id"]
+        return res
 
 def fanomaly_connector_and_send_test():
     test_name = "fanomaly_connector_and_send_test"
@@ -555,20 +566,26 @@ def fanomaly_connector_and_send_test():
 
     # GET REDIS DATA AND COMPARE
 
-    redis_data = buffer_filter.get_internal_redis_list_data(REDIS_ALERT_LIST)
-    expected_data = '"details": {"ip": "192.168.110.2","udp_nb_host": 1.000000,"udp_nb_port": 252.000000,"tcp_nb_host": 0.000000,"tcp_nb_port": 0.000000,"icmp_nb_host": 0.000000,"distance": 246.193959}'
+    with buffer_filter.redis.connect() as redis_connection:
+        redis_data = redis_connection.lrange(REDIS_ALERT_LIST, 0, -1)
+    expected_data = EXPECTED_ALERTS
 
-    if len(redis_data) != 1:
-        logging.error("{}: Expecting a single element list.".format(test_name))
+    # remove evt_id from expected alerts (anomaly generates a real evt_id)
+    for expected in expected_data:
+        del expected['evt_id']
+
+    if len(redis_data) != len(expected_data):
+        logging.error("{}: Expecting a list of {} elements".format(test_name, len(expected_data)))
         ret = False
 
 
-    redis_data = [a.decode() for a in redis_data]
+    redis_data = [format_alert(a.decode(), "fanomaly_connector_and_send_test") for a in redis_data]
 
-
-    if (expected_data not in redis_data[0]):
-        logging.error("{}: Expected this data : {} but got {} in redis".format(test_name, expected_data, redis_data))
-        ret = False
+    for data in redis_data:
+        if not data in expected_data:
+            logging.error("{}: entry wasn't expected {}".format(test_name, data))
+            logging.error("{}: expected data in {}".format(test_name, expected_data))
+            ret = False
 
     # CLEAN
     darwin_api.close()
@@ -588,9 +605,9 @@ def fsofa_connector_test():
     return redis_test(
         "fsofa_connector_test",
         [
-            ["", "net_src_ip", "net_dst_ip", "port", "ip_proto", "ip_1", "hostname", "os", "proto", "port", 1],
-            ["", "net_src_ip", "net_dst_ip", "port", "ip_proto", "ip_2", "hostname", "os", "proto", "port", 2],
-            ["", "net_src_ip", "net_dst_ip", "port", "ip_proto", "ip_3", "hostname", "os", "proto", "port", 3]
+            ["", "net_src_ip", "net_dst_ip", "port", "ip_proto", "ip_1", "hostname", "os", "proto", "port", 1, 1],
+            ["", "net_src_ip", "net_dst_ip", "port", "ip_proto", "ip_2", "hostname", "os", "proto", "port", 2, 2],
+            ["", "net_src_ip", "net_dst_ip", "port", "ip_proto", "ip_3", "hostname", "os", "proto", "port", 3, 3]
         ],
         [(
             "darwin_buffer_sofa",
@@ -601,3 +618,142 @@ def fsofa_connector_test():
             ]
         )]
     )
+
+
+def sum_tests(test_name, values=[], required_log_lines=0, expected_alert=1, init_data=None, init_data_type="key", should_start=True):
+    ret = True
+    config_test =   '{{' \
+                        '"redis_socket_path": "{redis_socket}",' \
+                        '"alert_redis_list_name": "{redis_alert}",' \
+                        '"alert_redis_channel_name": "{redis_alert_channel}"' \
+                    '}}'.format(redis_socket=REDIS_SOCKET,
+                                redis_alert=REDIS_ALERT_LIST,
+                                redis_alert_channel=REDIS_ALERT_CHANNEL)
+
+    config_buffer = '{{' \
+                        '"redis_socket_path": "{redis_socket}",' \
+                        '"input_format": [' \
+                            '{{"name": "decimal", "type": "float"}}' \
+                        '],' \
+                        '"outputs": [' \
+                            '{{' \
+                                '"filter_type": "sum",' \
+                                '"filter_socket_path": "/tmp/test.sock",' \
+                                '"interval": 10,' \
+                                '"required_log_lines": {required_log_lines},' \
+                                '"redis_lists": [{{' \
+                                    '"source": "",' \
+                                    '"name": "darwin_buffer_test"' \
+                                '}}]' \
+                            '}}' \
+                        ']' \
+                    '}}'.format(redis_socket=REDIS_SOCKET,
+                                required_log_lines=required_log_lines)
+
+    # CONFIG
+    buffer_filter = Buffer()
+    buffer_filter.configure(config_buffer)
+
+    test_filter = Filter(filter_name="test", socket_path="/tmp/test.sock")
+    test_filter.configure(config_test)
+
+    # Potentially add init data to redis
+    if init_data:
+        with buffer_filter.redis.connect() as redis_connection:
+            if init_data_type == "key":
+                redis_connection.set("darwin_buffer_test", init_data)
+            elif init_data_type == "list":
+                redis_connection.lpush("darwin_buffer_test", init_data)
+
+    # START FILTER
+    if should_start:
+        if not test_filter.valgrind_start():
+            print("test filter did not start")
+            return False
+        # FIXME cannot valgrind_start buffer while there is a problem with io_context destruction
+        if not buffer_filter.valgrind_start():
+            print("Buffer did not start")
+            return False
+
+
+        # SEND values
+        darwin_api = DarwinApi(socket_path=buffer_filter.socket,
+                            socket_type="unix")
+        for test_value in values:
+            darwin_api.call(
+                ["", test_value],
+                response_type="back",
+            )
+
+        sleep(15)
+
+        # GET REDIS DATA AND COMPARE
+        with buffer_filter.redis.connect() as redis_connection:
+            redis_data = redis_connection.lrange(REDIS_ALERT_LIST, 0, -1)
+
+        if len(redis_data) != expected_alert:
+            logging.error("{}: Expecting {} alert, but got {}".format(test_name, "one" if expected_alert else "no", len(redis_data)))
+            darwin_api.close()
+            return  False
+
+        if expected_alert:
+            if not buffer_filter.validate_alert_line(redis_data[0]):
+                logging.error("{}: could not validate alert\n{}".format(test_name, redis_data[0]))
+                darwin_api.close()
+                return  False
+
+            # already validated as a json by validate_alert_line()
+            log_line = json.loads(redis_data[0])
+            parsed_entry = json.loads(log_line['entry'])
+
+            if not len(parsed_entry) == 1:
+                logging.error("{}: there should only be 2 fields in output 'entry', but got {}".format(test_name, len(parsed_entry)))
+                logging.error("{}: entry is {}".format(test_name, parsed_entry))
+
+            # Test the delta of real and theoretical values, as Redis rounds up floats a bit "coarsely"
+            if abs(float(parsed_entry[0]) - sum(values)) > 1e-10:
+                logging.error("{}: alert entry is not what was expected\nexpected {}\nbut got {}".format(test_name, sum(values), parsed_entry[0]))
+                logging.error("{}: log is {}".format(test_name, log_line))
+                ret = False
+
+        # CLEAN
+        darwin_api.close()
+
+        test_filter.clean_files()
+        # ret = buffer_filter.valgrind_stop() or buffer_filter.valgrind_stop()
+        # would erase upper ret if this function return True
+        # FIXME cannot valgrind_stop buffer while there is a problem with io_context destruction
+        if not buffer_filter.valgrind_stop():
+            ret = False
+
+        if not test_filter.valgrind_stop():
+            ret = False
+    else:
+        #filter should not start
+        if buffer_filter.valgrind_start():
+            logging.error("{}: buffer filter started but it shouldn't have".format(test_name))
+            return False
+
+    return ret
+
+
+def sum_test_one_value():
+    # Buffer filter should send [-123.4] to test filter
+    return sum_tests("sum_test_one_value", values=[-123.4])
+
+def sum_test_multiple_values():
+    # Buffer filter should send [12263.6] (-123.4 + 42 + 12345) to test filter
+    return sum_tests("sum_test_multiple_values", values=[-123.4, 42, 12345])
+
+def sum_test_not_enough():
+    # Buffer filter should not send data even though sum is not null, as required_log_lines > abs(round(value))
+    return sum_tests("sum_test_multiple_values", values=[10.1], required_log_lines=11, expected_alert=0)
+
+def sum_reset_existing_key():
+    # Buffer should send 666.6, as initial 333.4 value in key should be deleted
+    return sum_tests("sum_reset_existing_key", values=[666.6], required_log_lines=1, init_data=333.4)
+
+def sum_existing_key_other_type():
+    # Buffer shouldn't start as the key used for the sum is already present AND another type
+    # (probably already used for someting else)
+    return sum_tests("sum_existing_key_other_type", init_data=42, init_data_type="list", should_start=False)

--- a/tests/filters/fsofa.py
+++ b/tests/filters/fsofa.py
@@ -4,7 +4,7 @@ import os
 from tools.filter import Filter
 from tools.output import print_result
 from darwin import DarwinApi
-from conf import MOCK_PATH, PYTHON_ENV_PATH
+from conf import TEST_FILES_DIR, PYTHON_ENV_PATH
 
 EXPECTED_HEADER = "IP,HOSTNAME,OS,PROTO,PORT"
 
@@ -12,7 +12,7 @@ class Sofa(Filter):
     def __init__(self):
         super().__init__(filter_name="sofa")
 
-    def configure(self, env=PYTHON_ENV_PATH, module="sofa_mock", function="main", test_dir=MOCK_PATH):
+    def configure(self, env=PYTHON_ENV_PATH, module="sofa_mock", function="main", test_dir=TEST_FILES_DIR):
         content = '{{\n' \
                   '"python_env_path": "{python_env_path}",\n' \
                   '"module": "{module}",\n' \

--- a/tests/filters/fvaml.py
+++ b/tests/filters/fvaml.py
@@ -1,0 +1,7 @@
+
+def run():
+    # This is a proprietary filter, tests are not implemented here
+    tests = []
+
+    for i in tests:
+        print_result("vaml: " + i.__name__, i)

--- a/tests/filters/fvast.py
+++ b/tests/filters/fvast.py
@@ -1,0 +1,7 @@
+
+def run():
+    # This is a proprietary filter, tests are not implemented here
+    tests = []
+
+    for i in tests:
+        print_result("vast: " + i.__name__, i)

--- a/tests/filters/test.py
+++ b/tests/filters/test.py
@@ -6,6 +6,8 @@ import filters.fconnection as fconnection
 import filters.fhostlookup as fhostlookup
 import filters.fyara as fyara
 import filters.fbuffer as fbuffer
+import filters.fvast as fvast
+import filters.fvaml as fvaml
 
 from tools.output import print_results
 
@@ -21,6 +23,8 @@ def run():
     fanomaly.run()
     fyara.run()
     fbuffer.run()
+    fvast.run()
+    fvaml.run()
 
     print()
     print()

--- a/tests/manager_socket/update_test.py
+++ b/tests/manager_socket/update_test.py
@@ -7,6 +7,8 @@ from tools.output import print_result
 
 def run():
     tests = [
+        wrong_manager_conf,
+        wrong_manager_conf_v2,
         no_filter_to_none,
         no_filter_to_one,
         no_filter_to_one_conf_v2,
@@ -22,30 +24,66 @@ def run():
         one_update_none_conf_v2,
         one_update_one,
         one_update_one_conf_v2,
-        one_update_one_wrong_conf,
-        one_update_one_wrong_conf_conf_v2,
+        one_update_one_wrong_filter_conf,
+        one_update_one_wrong_filter_conf_v2,
         many_update_none,
         many_update_none_conf_v2,
         many_update_one,
         many_update_one_conf_v2,
         many_update_many,
         many_update_many_conf_v2,
-        many_update_two_wrong_conf_conf_v2,
-        many_update_two_wrong_conf,
+        many_update_two_wrong_filter_conf,
+        many_update_two_wrong_filter_conf_v2,
         many_update_all,
         many_update_all_conf_v2,
-        many_update_all_wrong_conf,
-        many_update_all_wrong_conf_conf_v2,
+        many_update_all_wrong_filter_conf,
+        many_update_all_wrong_filter_conf_v2,
         non_existing_filter,
         non_existing_filter_conf_v2,
         update_no_filter,
         many_update_diff_one_more_v2,
         many_update_diff_one_less_v2,
         many_update_diff_one_more_one_less_v2,
+        one_update_one_wrong_manager_conf,
+        one_update_one_wrong_manager_conf_v2,
+        many_update_all_wrong_manager_conf,
+        many_update_all_wrong_manager_conf_v2,
+        many_update_two_less_wrong_then_good_manager_conf
     ]
 
     for i in tests:
         print_result("Update: " + i.__name__, i)
+
+
+def wrong_manager_conf():
+    ret = True
+
+    darwin_configure(CONF_ONE + "this is no valid JSON")
+    process = darwin_start()
+
+    sleep(1)
+    darwin_stop(process)
+    if process.returncode != 1:
+        logging.error("wrong_manager_conf: manager didn't return an error for the wrong configuration")
+        ret = False
+
+    darwin_remove_configuration()
+    return ret
+
+def wrong_manager_conf_v2():
+    ret = True
+
+    darwin_configure(CONF_ONE_V2 + "this is still not a valid JSON")
+    process = darwin_start()
+
+    sleep(1)
+    darwin_stop(process)
+    if process.returncode != 1:
+        logging.error("wrong_manager_conf_v2: manager didn't return an error for the wrong configuration")
+        ret = False
+
+    darwin_remove_configuration()
+    return ret
 
 
 def no_filter_to_none():
@@ -112,19 +150,19 @@ def no_filter_to_one_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if RESP_EMPTY not in resp:
-        logging.error("no_filter_to_one: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("no_filter_to_one_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_configure(CONF_ONE_V2)
     darwin_configure(CONF_FTEST, path=PATH_CONF_FTEST)
     resp = requests(REQ_UPDATE_ONE)
     if RESP_STATUS_OK not in resp:
-        logging.error("no_filter_to_one: Update response error; got \"{}\"".format(resp))
+        logging.error("no_filter_to_one_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if RESP_TEST_1 not in resp:
-        logging.error("no_filter_to_one: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("no_filter_to_one_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -171,19 +209,19 @@ def no_filter_to_many_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if RESP_EMPTY not in resp:
-        logging.error("no_filter_to_many: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("no_filter_to_many_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_configure(CONF_THREE_V2)
     darwin_configure(CONF_FTEST, path=PATH_CONF_FTEST)
     resp = requests(REQ_UPDATE_THREE)
     if RESP_STATUS_OK not in resp:
-        logging.error("no_filter_to_many: Update response error; got \"{}\"".format(resp))
+        logging.error("no_filter_to_many_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("no_filter_to_many: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("no_filter_to_many_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -230,18 +268,18 @@ def one_filter_to_none_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if RESP_TEST_1 not in resp:
-        logging.error("one_filter_to_none: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_filter_to_none_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_configure(CONF_EMPTY)
     resp = requests(REQ_UPDATE_ONE)
     if RESP_STATUS_OK not in resp:
-        logging.error("one_filter_to_none: Update response error; got \"{}\"".format(resp))
+        logging.error("one_filter_to_none_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if RESP_EMPTY not in resp:
-        logging.error("one_filter_to_none: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_filter_to_none_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -288,18 +326,18 @@ def many_filters_to_none_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("many_filters_to_none: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_filters_to_none_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_configure(CONF_EMPTY)
     resp = requests(REQ_UPDATE_THREE)
     if RESP_STATUS_OK not in resp:
-        logging.error("many_filters_to_none: Update response error; got \"{}\"".format(resp))
+        logging.error("many_filters_to_none_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if RESP_EMPTY not in resp:
-        logging.error("many_filters_to_none: Mismatching second monitor response; got \"{}\"".format(resp))
+        logging.error("many_filters_to_none_conf_v2: Mismatching second monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -350,20 +388,20 @@ def many_filters_to_one_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("many_filters_to_one: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_filters_to_one_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(1) # Need this because of the starting delay
     darwin_configure(CONF_ONE_V2)
     resp = requests(REQ_UPDATE_TWO)
     if RESP_STATUS_OK not in resp:
-        logging.error("many_filters_to_one: Update response error; got \"{}\"".format(resp))
+        logging.error("many_filters_to_one_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     sleep(1)
     resp = requests(REQ_MONITOR)
     if RESP_TEST_1 not in resp:
-        logging.error("many_filters_to_one: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_filters_to_one_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -413,19 +451,19 @@ def one_update_none_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if RESP_TEST_1 not in resp:
-        logging.error("one_update_none: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_update_none_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(1) # Need this because of the starting delay
     resp = requests(REQ_UPDATE_EMPTY)
     if RESP_STATUS_OK not in resp:
-        logging.error("one_update_none: Update response error; got \"{}\"".format(resp))
+        logging.error("one_update_none_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     sleep(1) # Need this because of the starting delay
     resp = requests(REQ_MONITOR)
     if RESP_TEST_1 not in resp:
-        logging.error("one_update_none: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_update_none_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -475,19 +513,19 @@ def one_update_one_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if RESP_TEST_1 not in resp:
-        logging.error("one_update_one: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_update_one_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(2) # Need this because of the starting delay
     resp = requests(REQ_UPDATE_ONE)
     if RESP_STATUS_OK not in resp:
-        logging.error("one_update_one: Update response error; got \"{}\"".format(resp))
+        logging.error("one_update_one_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     sleep(1) # Need this because of the starting delay
     resp = requests(REQ_MONITOR)
     if RESP_TEST_1 not in resp:
-        logging.error("one_update_one: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_update_one_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -496,7 +534,7 @@ def one_update_one_conf_v2():
     return ret
 
 
-def one_update_one_wrong_conf():
+def one_update_one_wrong_filter_conf():
 
     ret = True
 
@@ -506,23 +544,23 @@ def one_update_one_wrong_conf():
 
     resp = requests(REQ_MONITOR)
     if RESP_TEST_1 not in resp:
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_update_one_wrong_filter_conf: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(2) # Need this because of the starting delay
     darwin_configure(CONF_FTEST_WRONG_CONF, path=PATH_CONF_FTEST)
     resp = requests(REQ_UPDATE_ONE)
     if RESP_STATUS_KO not in resp:
-        logging.error("one_update_one_wrong_conf: Update response error; got \"{}\"".format(resp))
+        logging.error("one_update_one_wrong_filter_conf: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if RESP_TEST_1 not in resp:
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_update_one_wrong_filter_conf: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     if not check_filter_files("test_1", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("one_update_one_wrong_filter_conf: filter files check failed")
         ret = False
 
     darwin_stop(process)
@@ -531,7 +569,7 @@ def one_update_one_wrong_conf():
     return ret
 
 
-def one_update_one_wrong_conf_conf_v2():
+def one_update_one_wrong_filter_conf_v2():
 
     ret = True
 
@@ -541,23 +579,23 @@ def one_update_one_wrong_conf_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if RESP_TEST_1 not in resp:
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_update_one_wrong_filter_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(2) # Need this because of the starting delay
     darwin_configure(CONF_FTEST_WRONG_CONF, path=PATH_CONF_FTEST)
     resp = requests(REQ_UPDATE_ONE)
     if RESP_STATUS_KO not in resp:
-        logging.error("one_update_one_wrong_conf: Update response error; got \"{}\"".format(resp))
+        logging.error("one_update_one_wrong_filter_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if RESP_TEST_1 not in resp:
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_update_one_wrong_filter_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     if not check_filter_files("test_1", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("one_update_one_wrong_filter_conf_v2: filter files check failed")
         ret = False
 
     darwin_stop(process)
@@ -606,18 +644,18 @@ def many_update_none_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("many_update_none: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_none_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(1) # Need this because of the starting delay
     resp = requests(REQ_UPDATE_EMPTY)
     if RESP_STATUS_OK not in resp:
-        logging.error("many_update_none: Update response error; got \"{}\"".format(resp))
+        logging.error("many_update_none_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("many_update_none: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_none_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -666,18 +704,18 @@ def many_update_one_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("many_update_one: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_one_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(1) # Need this because of the starting delay
     resp = requests(REQ_UPDATE_ONE)
     if RESP_STATUS_OK not in resp:
-        logging.error("many_update_one: Update response error; got \"{}\"".format(resp))
+        logging.error("many_update_one_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("many_update_one: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_one_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -724,18 +762,18 @@ def many_update_many_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("many_update_many: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_many_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(1) # Need this because of the starting delay
     resp = requests(REQ_UPDATE_TWO)
     if RESP_STATUS_OK not in resp:
-        logging.error("many_update_many: Update response error; got \"{}\"".format(resp))
+        logging.error("many_update_many_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("many_update_many: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_many_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -744,7 +782,7 @@ def many_update_many_conf_v2():
     return ret
 
 
-def many_update_two_wrong_conf():
+def many_update_two_wrong_filter_conf():
 
     ret = True
 
@@ -754,27 +792,27 @@ def many_update_two_wrong_conf():
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_update_one_wrong_filter_conf: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(2) # Need this because of the starting delay
     darwin_configure(CONF_FTEST_WRONG_CONF, path=PATH_CONF_FTEST)
     resp = requests(REQ_UPDATE_TWO)
     if RESP_STATUS_KO not in resp:
-        logging.error("one_update_one_wrong_conf: Update response error; got \"{}\"".format(resp))
+        logging.error("one_update_one_wrong_filter_conf: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("one_update_one_wrong_filter_conf: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     if not check_filter_files("test_2", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("one_update_one_wrong_filter_conf: filter files check failed")
         ret = False
 
     if not check_filter_files("test_3", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("one_update_one_wrong_filter_conf: filter files check failed")
         ret = False
 
     darwin_stop(process)
@@ -783,7 +821,7 @@ def many_update_two_wrong_conf():
     return ret
 
 
-def many_update_two_wrong_conf_conf_v2():
+def many_update_two_wrong_filter_conf_v2():
 
     ret = True
 
@@ -793,27 +831,27 @@ def many_update_two_wrong_conf_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_two_wrong_filter_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(2) # Need this because of the starting delay
     darwin_configure(CONF_FTEST_WRONG_CONF, path=PATH_CONF_FTEST)
     resp = requests(REQ_UPDATE_TWO)
     if RESP_STATUS_KO not in resp:
-        logging.error("one_update_one_wrong_conf: Update response error; got \"{}\"".format(resp))
+        logging.error("many_update_two_wrong_filter_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_two_wrong_filter_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     if not check_filter_files("test_2", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("many_update_two_wrong_filter_conf_v2: filter files check failed")
         ret = False
 
     if not check_filter_files("test_3", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("many_update_two_wrong_filter_conf_v2: filter files check failed")
         ret = False
 
     darwin_stop(process)
@@ -822,7 +860,7 @@ def many_update_two_wrong_conf_conf_v2():
     return ret
 
 
-def many_update_all_wrong_conf():
+def many_update_all_wrong_filter_conf():
 
     ret = True
 
@@ -832,31 +870,31 @@ def many_update_all_wrong_conf():
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_all_wrong_filter_conf: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(2) # Need this because of the starting delay
     darwin_configure(CONF_FTEST_WRONG_CONF, path=PATH_CONF_FTEST)
     resp = requests(REQ_UPDATE_THREE)
     if RESP_STATUS_KO not in resp:
-        logging.error("one_update_one_wrong_conf: Update response error; got \"{}\"".format(resp))
+        logging.error("many_update_all_wrong_filter_conf: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_all_wrong_filter_conf: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     if not check_filter_files("test_1", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("many_update_all_wrong_filter_conf: filter files check failed")
         ret = False
 
     if not check_filter_files("test_2", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("many_update_all_wrong_filter_conf: filter files check failed")
         ret = False
 
     if not check_filter_files("test_3", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("many_update_all_wrong_filter_conf: filter files check failed")
         ret = False
 
     darwin_stop(process)
@@ -865,7 +903,7 @@ def many_update_all_wrong_conf():
     return ret
 
 
-def many_update_all_wrong_conf_conf_v2():
+def many_update_all_wrong_filter_conf_v2():
 
     ret = True
 
@@ -875,31 +913,31 @@ def many_update_all_wrong_conf_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_all_wrong_filter_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(2) # Need this because of the starting delay
     darwin_configure(CONF_FTEST_WRONG_CONF, path=PATH_CONF_FTEST)
     resp = requests(REQ_UPDATE_THREE)
     if RESP_STATUS_KO not in resp:
-        logging.error("one_update_one_wrong_conf: Update response error; got \"{}\"".format(resp))
+        logging.error("many_update_all_wrong_filter_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("one_update_one_wrong_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_all_wrong_filter_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     if not check_filter_files("test_1", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("many_update_all_wrong_filter_conf_v2: filter files check failed")
         ret = False
 
     if not check_filter_files("test_2", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("many_update_all_wrong_filter_conf_v2: filter files check failed")
         ret = False
 
     if not check_filter_files("test_3", ".1"):
-        logging.error("Error: filter files check failed")
+        logging.error("many_update_all_wrong_filter_conf_v2: filter files check failed")
         ret = False
 
     darwin_stop(process)
@@ -948,18 +986,18 @@ def many_update_all_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("many_update_all: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_all_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(1) # Need this because of the starting delay
     resp = requests(REQ_UPDATE_THREE)
     if RESP_STATUS_OK not in resp:
-        logging.error("many_update_all: Update response error; got \"{}\"".format(resp))
+        logging.error("many_update_all_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("many_update_all: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("many_update_all_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -1008,18 +1046,18 @@ def non_existing_filter_conf_v2():
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("non_existing_filter: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("non_existing_filter_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     sleep(1) # Need this because of the starting delay
     resp = requests(REQ_UPDATE_NON_EXISTING)
     if RESP_ERROR_FILTER_NOT_EXISTING not in resp:
-        logging.error("non_existing_filter: Update response error; got \"{}\"".format(resp))
+        logging.error("non_existing_filter_conf_v2: Update response error; got \"{}\"".format(resp))
         ret = False
 
     resp = requests(REQ_MONITOR)
     if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
-        logging.error("non_existing_filter: Mismatching monitor response; got \"{}\"".format(resp))
+        logging.error("non_existing_filter_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
         ret = False
 
     darwin_stop(process)
@@ -1151,6 +1189,220 @@ def many_update_diff_one_more_one_less_v2():
 
     if RESP_TEST_3 in resp:
         logging.error('many_update_diff_one_more_one_less_v2: Wrong filter in monitor response; got "{}"'.format(resp))
+        ret = False
+
+    darwin_stop(process)
+    darwin_remove_configuration()
+    darwin_remove_configuration(path=PATH_CONF_FTEST)
+    return ret
+
+
+def one_update_one_wrong_manager_conf():
+
+    ret = True
+
+    darwin_configure(CONF_ONE)
+    darwin_configure(CONF_FTEST, path=PATH_CONF_FTEST)
+    process = darwin_start()
+
+    resp = requests(REQ_MONITOR)
+    if RESP_TEST_1 not in resp:
+        logging.error("one_update_one_wrong_manager_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        ret = False
+
+    sleep(2) # Need this because of the starting delay
+    # add test at the end to invalidate configuration file json
+    darwin_configure(CONF_ONE + "Hello There")
+    resp = requests(REQ_UPDATE_ONE)
+    if RESP_STATUS_KO not in resp:
+        logging.error("one_update_one_wrong_manager_conf: Update response error; got \"{}\"".format(resp))
+        ret = False
+
+    resp = requests(REQ_MONITOR)
+    if RESP_TEST_1 not in resp:
+        logging.error("one_update_one_wrong_manager_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        ret = False
+
+    if not check_filter_files("test_1", ".1"):
+        logging.error("one_update_one_wrong_manager_conf: filter files check failed")
+        ret = False
+
+    darwin_stop(process)
+    darwin_remove_configuration()
+    darwin_remove_configuration(path=PATH_CONF_FTEST)
+    return ret
+
+
+def one_update_one_wrong_manager_conf_v2():
+
+    ret = True
+
+    darwin_configure(CONF_ONE_V2)
+    darwin_configure(CONF_FTEST, path=PATH_CONF_FTEST)
+    process = darwin_start()
+
+    resp = requests(REQ_MONITOR)
+    if RESP_TEST_1 not in resp:
+        logging.error("one_update_one_wrong_manager_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
+        ret = False
+
+    sleep(2) # Need this because of the starting delay
+    # add test at the end to invalidate configuration file json
+    darwin_configure(CONF_ONE_V2 + "Mystere au chocolat")
+    resp = requests(REQ_UPDATE_ONE)
+    if RESP_STATUS_KO not in resp:
+        logging.error("one_update_one_wrong_manager_conf_v2: Update response error; got \"{}\"".format(resp))
+        ret = False
+
+    resp = requests(REQ_MONITOR)
+    if RESP_TEST_1 not in resp:
+        logging.error("one_update_one_wrong_manager_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
+        ret = False
+
+    if not check_filter_files("test_1", ".1"):
+        logging.error("one_update_one_wrong_manager_conf_v2: filter files check failed")
+        ret = False
+
+    darwin_stop(process)
+    darwin_remove_configuration()
+    darwin_remove_configuration(path=PATH_CONF_FTEST)
+    return ret
+
+
+def many_update_all_wrong_manager_conf():
+
+    ret = True
+
+    darwin_configure(CONF_THREE)
+    darwin_configure(CONF_FTEST, path=PATH_CONF_FTEST)
+    process = darwin_start()
+
+    resp = requests(REQ_MONITOR)
+    if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
+        logging.error("one_update_one_wrong_manager_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        ret = False
+
+    sleep(2) # Need this because of the starting delay
+    # add test at the end to invalidate configuration file json
+    darwin_configure(CONF_THREE + "more is not always good")
+    resp = requests(REQ_UPDATE_THREE)
+    if RESP_STATUS_KO not in resp:
+        logging.error("one_update_one_wrong_manager_conf: Update response error; got \"{}\"".format(resp))
+        ret = False
+
+    resp = requests(REQ_MONITOR)
+    if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
+        logging.error("one_update_one_wrong_manager_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        ret = False
+
+    if not check_filter_files("test_1", ".1"):
+        logging.error("one_update_one_wrong_manager_conf: filter files check failed")
+        ret = False
+
+    if not check_filter_files("test_2", ".1"):
+        logging.error("one_update_one_wrong_manager_conf: filter files check failed")
+        ret = False
+
+    if not check_filter_files("test_3", ".1"):
+        logging.error("one_update_one_wrong_manager_conf: filter files check failed")
+        ret = False
+
+    darwin_stop(process)
+    darwin_remove_configuration()
+    darwin_remove_configuration(path=PATH_CONF_FTEST)
+    return ret
+
+
+def many_update_all_wrong_manager_conf_v2():
+
+    ret = True
+
+    darwin_configure(CONF_THREE_V2)
+    darwin_configure(CONF_FTEST, path=PATH_CONF_FTEST)
+    process = darwin_start()
+
+    resp = requests(REQ_MONITOR)
+    if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
+        logging.error("many_update_all_wrong_manager_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
+        ret = False
+
+    sleep(2) # Need this because of the starting delay
+    # add test at the end to invalidate configuration file json
+    darwin_configure(CONF_THREE_V2 + "}")
+    resp = requests(REQ_UPDATE_THREE)
+    if RESP_STATUS_KO not in resp:
+        logging.error("many_update_all_wrong_manager_conf_v2: Update response error; got \"{}\"".format(resp))
+        ret = False
+
+    resp = requests(REQ_MONITOR)
+    if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
+        logging.error("many_update_all_wrong_manager_conf_v2: Mismatching monitor response; got \"{}\"".format(resp))
+        ret = False
+
+    if not check_filter_files("test_1", ".1"):
+        logging.error("many_update_all_wrong_manager_conf_v2: filter files check failed")
+        ret = False
+
+    if not check_filter_files("test_2", ".1"):
+        logging.error("many_update_all_wrong_manager_conf_v2: filter files check failed")
+        ret = False
+
+    if not check_filter_files("test_3", ".1"):
+        logging.error("many_update_all_wrong_manager_conf_v2: filter files check failed")
+        ret = False
+
+    darwin_stop(process)
+    darwin_remove_configuration()
+    darwin_remove_configuration(path=PATH_CONF_FTEST)
+    return ret
+
+def many_update_two_less_wrong_then_good_manager_conf():
+
+    ret = True
+
+    darwin_configure(CONF_THREE)
+    darwin_configure(CONF_FTEST, path=PATH_CONF_FTEST)
+    process = darwin_start()
+
+    resp = requests(REQ_MONITOR)
+    if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
+        logging.error("many_update_two_less_wrong_then_good_manager_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        ret = False
+
+    sleep(2) # Need this because of the starting delay
+    # add test at the end to invalidate configuration file json
+    darwin_configure(CONF_THREE + "}")
+    resp = requests(REQ_UPDATE_EMPTY)
+    if RESP_STATUS_KO not in resp:
+        logging.error("many_update_two_less_wrong_then_good_manager_conf: Update response error; got \"{}\"".format(resp))
+        ret = False
+
+    resp = requests(REQ_MONITOR)
+    if not all(x in resp for x in [RESP_TEST_1, RESP_TEST_2, RESP_TEST_3]):
+        logging.error("many_update_two_less_wrong_then_good_manager_conf: Mismatching monitor response; got \"{}\"".format(resp))
+        ret = False
+
+    darwin_configure(CONF_ONE)
+    resp = requests(REQ_UPDATE_EMPTY)
+    if RESP_STATUS_OK not in resp:
+        logging.error("many_update_two_less_wrong_then_good_manager_conf: expected OK but got \"{}\"".format(resp))
+        ret = False
+
+    resp = requests(REQ_MONITOR)
+    if not all(x in resp for x in [RESP_TEST_1]):
+        logging.error("many_update_two_less_wrong_then_good_manager_conf: Expected one running filter but got \"{}\"".format(resp))
+        ret = False
+
+    if not check_filter_files("test_1", ".1"):
+        logging.error("many_update_two_less_wrong_then_good_manager_conf: filter files check failed")
+        ret = False
+
+    if check_filter_files("test_2", ".1"):
+        logging.error("many_update_two_less_wrong_then_good_manager_conf: filter files check failed")
+        ret = False
+
+    if check_filter_files("test_3", ".1"):
+        logging.error("many_update_two_less_wrong_then_good_manager_conf: filter files check failed")
         ret = False
 
     darwin_stop(process)

--- a/tests/tools/darwin_utils.py
+++ b/tests/tools/darwin_utils.py
@@ -1,17 +1,17 @@
 import subprocess
 import os
 from time import sleep
-from conf import DEFAULT_MANAGER_PATH, DEFAULT_CONFIGURATION_PATH, DEFAULT_PYTHON_EXEC
+from conf import DEFAULT_MANAGER_PATH, DEFAULT_PYTHON_EXEC, TEST_FILES_DIR
 
 
-def darwin_start(darwin_manager_path=DEFAULT_MANAGER_PATH, config_path=DEFAULT_CONFIGURATION_PATH):
+def darwin_start(darwin_manager_path=DEFAULT_MANAGER_PATH, config_path="{}/darwin.conf".format(TEST_FILES_DIR)):
     process = subprocess.Popen([
         DEFAULT_PYTHON_EXEC,
         darwin_manager_path,
         '-l',
         'DEBUG',
         '-p',
-        '/tmp',
+        TEST_FILES_DIR,
         '--no-suffix-directories',
         config_path
     ])
@@ -23,9 +23,9 @@ def darwin_stop(process):
     process.terminate()
     process.wait()
 
-def darwin_configure(conf, path=DEFAULT_CONFIGURATION_PATH):
+def darwin_configure(conf, path="{}/darwin.conf".format(TEST_FILES_DIR)):
     with open(path, mode='w') as file:
         file.write(conf)
 
-def darwin_remove_configuration(path=DEFAULT_CONFIGURATION_PATH):
+def darwin_remove_configuration(path="{}/darwin.conf".format(TEST_FILES_DIR)):
     os.remove(path)

--- a/tests/tools/filter.py
+++ b/tests/tools/filter.py
@@ -1,10 +1,11 @@
+import json
 import logging
 import os
 import os.path
 import uuid
 import subprocess
 
-from conf import DEFAULT_FILTER_PATH, VALGRIND_MEMCHECK
+from conf import DEFAULT_FILTER_PATH, VALGRIND_MEMCHECK, TEST_FILES_DIR
 from darwin import DarwinApi
 from time import sleep
 from tools.redis_utils import RedisServer
@@ -18,15 +19,23 @@ class Filter():
 
     def __init__(self, path=None, config_file=None, filter_name="filter", socket_path=None, monitoring_socket_path=None, pid_file=None, output="NONE", next_filter_socket_path="no", nb_threads=1, cache_size=0, threshold=101, log_level="DEVELOPER"):
         self.filter_name = filter_name
-        self.socket = socket_path if socket_path else "/tmp/{}.sock".format(filter_name)
-        self.config = config_file if config_file else "/tmp/{}.conf".format(filter_name)
+        self.socket = socket_path if socket_path else "{}/{}.sock".format(TEST_FILES_DIR, filter_name)
+        self.config = config_file if config_file else "{}/{}.conf".format(TEST_FILES_DIR, filter_name)
         self.path = path if path else "{}darwin_{}".format(DEFAULT_FILTER_PATH, filter_name)
-        self.monitor = monitoring_socket_path if monitoring_socket_path else "/tmp/{}_mon.sock".format(filter_name)
-        self.pid = pid_file if pid_file else "/tmp/{}.pid".format(filter_name)
+        self.monitor = monitoring_socket_path if monitoring_socket_path else "{}/{}_mon.sock".format(TEST_FILES_DIR, filter_name)
+        self.pid = pid_file if pid_file else "{}/{}.pid".format(TEST_FILES_DIR, filter_name)
         self.cmd = [self.path, "-l", log_level, self.filter_name, self.socket, self.config, self.monitor, self.pid, output, next_filter_socket_path, str(nb_threads), str(cache_size), str(threshold)]
         self.process = None
         self.error_code = 99 # For valgrind testing
         self.pubsub = None
+        self.prepare_log_file()
+
+    def prepare_log_file(self):
+        # TODO variabilize once path can be changed
+        self.log_file = open("/var/log/darwin/darwin.log", 'a+')
+        if self.log_file is None:
+            logging.error("Could not open darwin.log")
+            return False
 
     def __del__(self):
         if self.process and self.process.poll() is None:
@@ -35,6 +44,11 @@ class Filter():
             else:
                 self.valgrind_stop()
         self.clean_files()
+        try:
+            if self.log_file is not None and not self.log_file.closed:
+                self.log_file.close()
+        except AttributeError:
+            pass
 
     def check_start(self):
         if not os.path.exists(self.pid):
@@ -79,7 +93,8 @@ class Filter():
             return self.start()
         command = ['valgrind',
                    '--tool=memcheck',
-                   '--leak-check=yes',
+                   '--leak-check=full',
+                   '--errors-for-leak-kinds=definite',
                    '-q', # Quiet mode so it doesn't pollute the output
                    '--error-exitcode={}'.format(self.error_code), #If valgrind reports error(s) during the run, return this exit code.
                    ] + self.cmd
@@ -91,7 +106,6 @@ class Filter():
     def valgrind_stop(self):
         if VALGRIND_MEMCHECK is False:
             return self.stop()
-        sleep(3)
         self.process.terminate()
         try:
             self.process.wait(15) # Valgrind can take some time, so it needs a generous timeout
@@ -102,11 +116,15 @@ class Filter():
             return False
 
         # If valgrind return the famous error code
+        out, err = self.process.communicate()
         if self.process.returncode == self.error_code :
-            out, err = self.process.communicate()
+            print("\033[91m[Valgrind error(s)]\33[0m", end='', flush=True)
             logging.error("Valgrind returned error code: {}".format(self.process.returncode))
-            logging.error("Valgrind error: {}".format(err))
+            logging.error("Valgrind error: {}".format(err.decode()))
             return False
+        elif err:
+            print("\33[33m[Valgrind warning(s)]\33[0m", end='', flush=True)
+            logging.error("Valgrind warning: {}".format(err.decode()))
 
         return self.check_stop()
 
@@ -143,7 +161,78 @@ class Filter():
         Send a single line.
         """
         api = DarwinApi(socket_type="unix", socket_path=self.socket)
-        ret = api.call([line], response_type="back")
+        ret = api.call(line, response_type="back")
 
         api.close()
         return ret
+
+
+    def validate_alert_line(self, alert_line, details_checks=[]):
+        try:
+            # Check if the alert is a valid json
+            json_line = json.loads(alert_line)
+        except Exception as e:
+            logging.error("filter: alert_line is not a valid json: {}".format(e))
+            return False
+
+        for key, key_type in [
+            ("alert_type", "str"),
+            ("alert_subtype", "str"),
+            ("alert_time", "str"),
+            ("level", "str"),
+            ("rule_name", "str"),
+            ("tags", "list"),
+            ("entry", "str"),
+            ("score", "int"),
+            ("evt_id", "str"),
+            ("details", "dict"),
+            ]:
+            # Check if key is present in alert
+            if key not in json_line:
+                logging.error("filter: key '{}' not in alert line".format(key))
+                logging.error("filter: alert line is {}".format(alert_line))
+                return False
+
+            # Check if the key is the correct type
+            real_key_type = type(json_line[key]).__name__
+            if real_key_type != key_type:
+                logging.error("filter: alert key '{}' is not the expected type, got '{}' but expected '{}'".format(key, real_key_type, key_type))
+                logging.error("filter: alert line is\n{}".format(alert_line))
+                return False
+
+            if key == "details" and details_checks:
+                for subkey, subkey_type in details_checks:
+                    # Check if key is present in alert
+                    if subkey not in json_line[key]:
+                        logging.error("filter: key '{}' not in alert details line".format(subkey))
+                        logging.error("filter: alert line is\n{}".format(alert_line))
+                        return False
+
+                    # Check if the subkey is the correct type
+                    real_subkey_type = type(json_line[key][subkey]).__name__
+                    if real_subkey_type != subkey_type:
+                        logging.error("filter: alert details key '{}' is not the expected type, got '{}' but expected '{}'".format(subkey, real_subkey_type, subkey_type))
+                        logging.error("filter: alert line is\n{}".format(alert_line))
+                        return False
+
+
+        return True
+    def check_line_in_filter_log(self, line, keep_init_pos=True):
+        found = False
+        if self.log_file is None or self.log_file.closed:
+            logging.error("check_line_in_filter_log: cannot use log file to check line {}".format(line))
+            return False
+
+        init_pos = self.log_file.tell()
+        file_line = self.log_file.readline()
+        while file_line:
+            if line in file_line:
+                found = True
+                break
+            file_line = self.log_file.readline()
+
+        # Go back to initial position in file
+        if keep_init_pos:
+            self.log_file.seek(init_pos, 0)
+
+        return found

--- a/tests/tools/utils.py
+++ b/tests/tools/utils.py
@@ -1,0 +1,54 @@
+import operator as op
+
+class ApproxDict(object):
+    def __init__(self, iterable=(), float_eq=op.eq):
+        self._float_eq = float_eq
+        self._dict = dict(iterable)
+
+    def __getitem__(self, key):
+        return self._dict[key]
+
+    def __setitem__(self, key, val):
+        self._dict[key] = val
+
+    def __iter__(self):
+        return iter(self._dict)
+
+    def __len__(self):
+        return len(self._dict)
+
+    def __contains__(self, key):
+        return key in self._dict
+
+    def __str__(self):
+        return self._dict.__str__()
+
+    def __repr__(self):
+        return self._dict.__repr__()
+
+    def __eq__(self, other):
+        def compare(a, b):
+            if isinstance(a, float) and isinstance(b, float):
+                return self._float_eq(a, b)
+            else:
+                return a == b
+        try:
+            if len(self) != len(other):
+                return False
+            for key in self:
+                if not compare(self[key], other[key]):
+                    return False
+            return True
+        except Exception:
+            return False
+
+    def __getattr__(self, attr):
+        attr_val = getattr(self._dict, attr)
+        if callable(attr_val):
+            def wrapper(*args, **kwargs):
+                result = attr_val(*args, **kwargs)
+                if isinstance(result, dict):
+                    return ApproxDict(result, self._float_eq)
+                return result
+            return wrapper
+        return attr_val


### PR DESCRIPTION
# Changelog

## Core


## Filters

### BUFR
- Add 'float' type to valid input formats
- [BREAKING] Buffer checks keys in Redis, won't start if key is of wrong type and will delete the key to avoid using stale/improper data
- [NEW] Add 'sum' buffer
  - Increments a redis key to calculate sum over a time span
  - Can take positive and negative values, represented as integers or floats (handled as floats internally)
  - 'required_log_lines' represent a limit under which not to use the absolute rounded value of the sum
  - Value is never reinserted in case of error -> won't stack sums in different time intervals
  - [FIX] Removing the modification of the wrong statistic value.

## Manager
- [FIX] Avoid Manager crashing when updating a configuration with syntax errors
  - Added associated tests
- Add RFC3339 'timestamp' field to stats generated

## CMakeLists
- Add VAST file inclusion (proprietary)
- Add VAML file inclusion (proprietary)
- Add option to activate coverage flags

## Functional tests
- Add mock test file
- Change tests to include new 'float' input type in entries
- Update anomaly test to adapt to new algorithm
- Add tests for new 'sum' filter
  - test with one value sent
  - test with several (negative, positive, integer) values to test correct summing
  - test with sum under 'required_log_lines'
  - test with existing correct type key overrode at startup
  - test with existing incorrect type key, preventing filter to start

## Test framework
- [FEATURE] Add capability to check lines are present in logs
- [FEATURE] Add an ApproxDict class to check float equality with delta in dictionaries
- [FEATURE] Add a generic filter function to validate fields in generated filters' alerts
- Reuse MOCK_PATH into TEST_FILES_DIR to specify runtime temp dir
- Improve Valgrind print returns
- Remove useless sleep after stop
- Add mock test file for VAML/VAST

## TEST filter
- Allow ftest to get lists AND simple values
- Simple values are interpreted as string, but can also be numbers

## Dockerfile
- Build boost:date_time (required for proprietary VAML)