### PR TITLE
Core improvements: add parameters to filters

### DIFF
--- a/manager/Services.py
+++ b/manager/Services.py
@@ -170,12 +170,10 @@ class Services:
             logger.error("cannot start filter: " + str(e))
             filter['status'] = psutil.STATUS_DEAD
             return False
-        try:
-            p.wait(timeout=1)
-        except TimeoutExpired:
-            if filter['log_level'].lower() == "debug":
-                logger.debug("Debug mode enabled. Ignoring timeout at process startup.")
-            else:
+        if filter['log_level'].lower() != "debug":
+            try:
+                p.wait(timeout=10)
+            except TimeoutExpired:
                 logger.error("Error starting filter. Did not daemonize before timeout. Killing it.")
                 p.kill()
                 p.wait()

--- a/samples/base/Core.cpp
+++ b/samples/base/Core.cpp
@@ -117,7 +117,7 @@ namespace darwin {
                 case 'l':
                     log_level.assign(optarg);
                     if(!Core::SetLogLevel(log_level)){
-                        std::clog << "Unknown log-level " << optarg << std::endl << std::endl;
+                        std::cerr << "Unknown log-level " << optarg << std::endl << std::endl;
                         Core::Usage();
                         return false;
                     }
@@ -126,11 +126,11 @@ namespace darwin {
                     Core::Usage();
                     return false;
                 case ':':
-                    std::clog << "Missing an option argument for -" << (char)optopt << std::endl << std::endl;
+                    std::cerr << "Missing an option argument for -" << (char)optopt << std::endl << std::endl;
                     Core::Usage();
                     return false;
                 case '?':
-                    std::clog << "Unknown option -" << (char)optopt << std::endl << std::endl;
+                    std::cerr << "Unknown option -" << (char)optopt << std::endl << std::endl;
                     Core::Usage();
                     return false;
             }
@@ -138,7 +138,7 @@ namespace darwin {
 
         // After options we need 10 mandatory arguments
         if (ac-optind < 10) {
-            std::clog << "Missing some parameters" << std::endl << std::endl;
+            std::cerr << "Missing some parameters" << std::endl << std::endl;
             Core::Usage();
             return false;
         }

--- a/samples/base/Logger.cpp
+++ b/samples/base/Logger.cpp
@@ -18,18 +18,22 @@
 namespace darwin {
     namespace logger {
 
-        Logger::Logger() : _logLevel(Warning) {
-            _file = std::ofstream(DARWIN_LOG_FILE, std::ios::out | std::ios::app);
-            if (!_file.is_open())
-                std::clog << "Can't open log file " << DARWIN_LOG_FILE << std::endl;
+        Logger::~Logger() {
+            if (_file.is_open())
+                _file.close();
         }
 
-        Logger::~Logger() {
-            _file.close();
+        bool Logger::openLogFile() {
+            _file = std::ofstream(_filepath, std::ios::out | std::ios::app);
+            if (not _file.is_open()) {
+                std::clog << "Can't open log file " << _filepath << std::endl;
+                return false;
+            }
+            return true;
         }
 
         void Logger::log(log_type type, std::string const& logMsg) {
-            if (type < this->_logLevel || !_file.is_open())
+            if (type < this->_logLevel)
                 return;
 
             std::string date = darwin::time_utils::GetTime();
@@ -60,9 +64,13 @@ namespace darwin {
             fmt << "\"filter\":\"" << _name << "\",";
             fmt << "\"message\":\"" << logMsg << "\"";
             fmt << '}';
-            _fileMutex.lock();
-            _file << fmt.str().c_str() << std::endl;
-            _fileMutex.unlock();
+            if (not _file.is_open() and not this->openLogFile()) {
+                std::clog << fmt.str() << std::endl;
+            } else {
+                _fileMutex.lock();
+                _file << fmt.str().c_str() << std::endl;
+                _fileMutex.unlock();
+            }
         }
 
         void Logger::setLevel(darwin::logger::log_type type) {
@@ -88,13 +96,36 @@ namespace darwin {
             _name = name;
         }
 
+        bool Logger::setFilePath(std::string const& filepath) {
+            bool ret = true;
+
+            std::ofstream testfile = std::ofstream(filepath, std::ios::out | std::ios::app);
+
+            if (!testfile.is_open()) {
+                std::clog << "Can't open log file " << filepath << std::endl;
+                ret = false;
+            } else {
+                _filepath = filepath;
+                _file.swap(testfile);
+            }
+
+            if (testfile.is_open())
+                testfile.close();
+
+            return ret;
+        }
+
         void Logger::RotateLogs() {
             _fileMutex.lock();
-            _file.close();
-            _file = std::ofstream(DARWIN_LOG_FILE, std::ios::out | std::ios::app);
-            if (!_file.is_open())
-                std::clog << "Can't open log file " << DARWIN_LOG_FILE
-                            << std::endl;
+
+            if (_file.is_open())
+                _file.close();
+
+            _file = std::ofstream(_filepath, std::ios::out | std::ios::app);
+
+            if (!_file.is_open()) {
+                std::clog << "Can't open log file " << _filepath << std::endl;
+            }
             _fileMutex.unlock();
         }
     }

--- a/samples/base/Logger.cpp
+++ b/samples/base/Logger.cpp
@@ -67,9 +67,8 @@ namespace darwin {
             if (not _file.is_open() and not this->openLogFile()) {
                 std::clog << fmt.str() << std::endl;
             } else {
-                _fileMutex.lock();
+                std::lock_guard lock(_fileMutex);
                 _file << fmt.str().c_str() << std::endl;
-                _fileMutex.unlock();
             }
         }
 
@@ -109,14 +108,11 @@ namespace darwin {
                 _file.swap(testfile);
             }
 
-            if (testfile.is_open())
-                testfile.close();
-
             return ret;
         }
 
         void Logger::RotateLogs() {
-            _fileMutex.lock();
+            std::lock_guard lock(_fileMutex);
 
             if (_file.is_open())
                 _file.close();
@@ -126,7 +122,6 @@ namespace darwin {
             if (!_file.is_open()) {
                 std::clog << "Can't open log file " << _filepath << std::endl;
             }
-            _fileMutex.unlock();
         }
     }
 }

--- a/samples/base/Logger.hpp
+++ b/samples/base/Logger.hpp
@@ -16,9 +16,9 @@
 
 // Default log files
 
-#  ifndef DARWIN_LOG_FILE
-#   define DARWIN_LOG_FILE "/var/log/darwin/darwin.log"
-#  endif //!DARWIN_LOG_FILE
+#  ifndef DARWIN_DEFAULT_LOG_FILE
+#   define DARWIN_DEFAULT_LOG_FILE "/var/log/darwin/darwin.log"
+#  endif //!DARWIN_DEFAULT_LOG_FILE
 
 #  ifndef DARWIN_LOGGER
 #   define DARWIN_LOGGER darwin::logger::Logger& log = darwin::logger::Logger::instance()
@@ -100,16 +100,24 @@ namespace darwin {
             /// \param name The name to set as the module name.
             void setName(std::string const& name);
 
+            /// \brief Set the output logfile fullpath
+            /// \param filepath the fullpath to the logfile
+            bool setFilePath(std::string const& filepath);
+
             ///Rotate logs
             void RotateLogs();
 
         private:
             /// \brief This is the constructor of logger object.
             /// This constructor is private because only getLogger method can call it.
-            Logger();
+            Logger() : _logLevel(Warning) {};
 
             /// \brief This is the destructor of logger object.
             ~Logger();
+
+            /// \brief This function opens the log file to be used by the logger
+            /// \warning internal _file object should be closed before calling the function
+            bool openLogFile();
 
             /// \brief Copy operator.
             /// \param other, The logger to copy
@@ -125,6 +133,7 @@ namespace darwin {
 
         private:
             log_type _logLevel;
+            std::string _filepath = DARWIN_DEFAULT_LOG_FILE;
             std::ofstream _file;
             std::string _name;
             std::mutex _fileMutex;

--- a/tests/tools/filter.py
+++ b/tests/tools/filter.py
@@ -18,24 +18,30 @@ REDIS_CHANNEL_NAME = "darwin.tests"
 
 class Filter():
 
-    def __init__(self, path=None, config_file=None, filter_name="filter", socket_path=None, monitoring_socket_path=None, pid_file=None, output="NONE", next_filter_socket_path="no", nb_threads=1, cache_size=0, threshold=101, log_level="DEVELOPER"):
+    def __init__(self, path=None, config_file=None, filter_name="filter", socket_path=None, monitoring_socket_path=None, pid_file=None, output="NONE", next_filter_socket_path="no", nb_threads=1, cache_size=0, threshold=101, log_level="DEVELOPER", log_filepath=None):
         self.filter_name = filter_name
         self.socket = socket_path if socket_path else "{}/{}.sock".format(TEST_FILES_DIR, filter_name)
         self.config = config_file if config_file else "{}/{}.conf".format(TEST_FILES_DIR, filter_name)
         self.path = path if path else "{}darwin_{}".format(DEFAULT_FILTER_PATH, filter_name)
         self.monitor = monitoring_socket_path if monitoring_socket_path else "{}/{}_mon.sock".format(TEST_FILES_DIR, filter_name)
         self.pid = pid_file if pid_file else "{}/{}.pid".format(TEST_FILES_DIR, filter_name)
-        self.cmd = [self.path, "-l", log_level, self.filter_name, self.socket, self.config, self.monitor, self.pid, output, next_filter_socket_path, str(nb_threads), str(cache_size), str(threshold)]
         self.process = None
         self.error_code = 99 # For valgrind testing
         self.pubsub = None
+        self.log_level = log_level
+        self.output = output
+        self.nb_threads = nb_threads
+        self.cache_size = cache_size
+        self.threshold = threshold
+        self.next_filter_socket_path = next_filter_socket_path
+        self.log_filepath = log_filepath
         self.prepare_log_file()
 
     def prepare_log_file(self):
-        # TODO variabilize once path can be changed
-        self.log_file = open("/var/log/darwin/darwin.log", 'a+')
+        filepath = self.log_filepath if self.log_filepath else DEFAULT_LOG_FILE
+        self.log_file = open(filepath, 'a+')
         if self.log_file is None:
-            logging.error("Could not open darwin.log")
+            logging.error("Could not open log file {}".format(filepath))
             return False
 
     def __del__(self):
@@ -50,6 +56,13 @@ class Filter():
                 self.log_file.close()
         except AttributeError:
             pass
+
+    @property
+    def cmd(self):
+        if self.log_filepath is not None:
+            return [self.path, "-l", self.log_level, "-n", "-o", self.log_filepath, self.filter_name, self.socket, self.config, self.monitor, self.pid, self.output, self.next_filter_socket_path, str(self.nb_threads), str(self.cache_size), str(self.threshold)]
+        else:
+            return [self.path, "-l", self.log_level, "-n", self.filter_name, self.socket, self.config, self.monitor, self.pid, self.output, self.next_filter_socket_path, str(self.nb_threads), str(self.cache_size), str(self.threshold)]
 
     def check_start(self):
         if not os.path.exists(self.pid):
@@ -148,6 +161,11 @@ class Filter():
 
         try:
             os.remove(self.pid)
+        except:
+            pass
+
+        try:
+            os.remove(self.log_file)
         except:
             pass
 


### PR DESCRIPTION
# :sparkles: Core improvements: add parameters to filters

## :page_with_curl: Type of change

**New feature**: non-breaking change which adds functionality.

## :bulb: Related Issue(s)

- no related issues

## :black_nib: Description

### Added
- [CORE] **-n**  parameter to keep filter from daemonizing
- [CORE] **-o <logfile>** parameter to direct logs to a different file
- [TESTS] test to check the **-o** parameter

### Changed
- [CORE] errors in parameters parsing are now directed to stderr

### Fixed
- [MANAGER] wait long enough for a filter to start before declaring it dead

## :dart: Test Environments

### HBSD 12.2
- gcc (10.2.0)
- CMake (3.19.5)
- Python (3.7.7)

### Ubuntu (18.04)
- gcc (7.5.0)
- CMake (3.10.2)
- Python (3.6.9)
- Valgrind (3.13.0)

## :heavy_check_mark: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] (**If other changes**) I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

</br>

- [x] :raising_hand: **I certify on my honor that all the information provided is true, and I've done all I can to deliver a high quality code**
