### PR TITLE
Redis improvements and fixes

### DIFF
--- a/samples/base/AlertManager.hpp
+++ b/samples/base/AlertManager.hpp
@@ -112,16 +112,31 @@ namespace darwin {
         /// \brief Configure the RedisManager.
         /// \param redis_socket_path The path to the redis socket used for alerting
         /// \return True on success, false on error
-        bool ConfigRedis(std::string redis_socket_path);
+        bool ConfigRedis(const std::string redis_socket_path);
+
+        /// \brief Configure the RedisManager.
+        /// \param redis_ip The ip to the redis node used for alerting
+        /// \param redis_port The port to the redis node used for alerting
+        /// \return True on success, false on error
+        bool ConfigRedis(const std::string redis_ip, const int redis_port);
 
         /// \brief Check and extract `field_name' of `configuration'. `field_name' *MUST* be a string.
         /// \param configuration The configurations a json object.
         /// \param field_name The field name. Creating a string here would be pointless.
-        /// \param var The string object ot fill with the extracted value. Initial value is not modified on error.
+        /// \param var The string object to fill with the extracted value. Initial value is not modified on error.
         /// \return False on error, true on success. Logs appropriately.
         static bool GetStringField(const rapidjson::Document& configuration,
                                    const char* const field_name,
                                    std::string& var);
+
+        /// \brief Check and extract `field_name' of `configuration'. `field_name' *MUST* be an unsigned integer.
+        /// \param configuration The configurations a json object.
+        /// \param field_name The field name. Creating a string here would be pointless.
+        /// \param var The unsigned integer object to fill with the extracted value. Initial value is not modified on error.
+        /// \return False on error, true on success. Logs appropriately.
+        static bool GetUIntField(const rapidjson::Document& configuration,
+                                   const char* const field_name,
+                                   unsigned int& var);
 
         /// \brief Write the logs in file
         /// \return True on success, false on error

--- a/samples/fbuffer/Connectors/AConnector.cpp
+++ b/samples/fbuffer/Connectors/AConnector.cpp
@@ -69,7 +69,7 @@ bool AConnector::PrepareKeysInRedis(){
         DARWIN_LOG_DEBUG("AConnector::PrepareKeysInRedis:: key '"+ redis_list + "' is '" + reply + "'");
 
         if(reply != "none") {
-            if(reply != "list") {
+            if(reply != "set") {
                 DARWIN_LOG_ERROR("AConnector::PrepareKeysInRedis:: key '" + redis_list + "' is already present "
                                     "but seems to be used for something else, "
                                     "cannot start the filter and risk overriding data in Redis");

--- a/samples/fconnection/Generator.hpp
+++ b/samples/fconnection/Generator.hpp
@@ -32,6 +32,8 @@ protected:
 
 private:
     bool ConfigRedis(const std::string &redis_socket_path,
+                     const std::string &redis_ip,
+                     unsigned int redis_port,
                      const std::string &init_data_path);
 
     unsigned int _redis_expire = 0;

--- a/samples/fend/Generator.cpp
+++ b/samples/fend/Generator.cpp
@@ -59,21 +59,47 @@ bool Generator::LoadClassifier(const rapidjson::Document &configuration) {
     DARWIN_LOGGER;
     DARWIN_LOG_DEBUG("End:: Generator:: Loading classifier...");
 
-    if (!configuration.HasMember("redis_socket_path")) {
-        DARWIN_LOG_CRITICAL("End:: Generator:: Missing parameter: 'redis_socket_path'");
-        return false;
+    std::string redis_socket_path, redis_ip;
+    unsigned int redis_port = 6379;
+
+    if(configuration.HasMember("redis_socket_path")) {
+        if (not configuration["redis_socket_path"].IsString()) {
+            DARWIN_LOG_CRITICAL("End:: Generator:: 'redis_socket_path' needs to be a string");
+            return false;
+        } else {
+            redis_socket_path = configuration["redis_socket_path"].GetString();
+        }
     }
 
-    if (!configuration["redis_socket_path"].IsString()) {
-        DARWIN_LOG_CRITICAL("End:: Generator:: 'redis_socket_path' needs to be a string");
-        return false;
+    if(configuration.HasMember("redis_ip")) {
+        if (not configuration["redis_ip"].IsString()) {
+            DARWIN_LOG_CRITICAL("End:: Generator:: 'redis_ip' needs to be a string");
+            return false;
+        } else {
+            redis_ip = configuration["redis_ip"].GetString();
+        }
     }
 
-    std::string redis_socket_path = configuration["redis_socket_path"].GetString();
+    if(configuration.HasMember("redis_port")) {
+        if (not configuration["redis_port"].IsUint()) {
+            DARWIN_LOG_CRITICAL("End:: Generator:: 'redis_port' needs to be an unsigned integer");
+            return false;
+        } else {
+            redis_port = configuration["redis_port"].GetUint();
+        }
+    }
 
     darwin::toolkit::RedisManager& redis = darwin::toolkit::RedisManager::GetInstance();
     // Done in AlertManager before arriving here, but will allow better transition from redis singleton
-    redis.SetUnixConnection(redis_socket_path);
+    if (not redis_socket_path.empty()) {
+        redis.SetUnixConnection(redis_socket_path);
+    } else if (not redis_ip.empty()) {
+        redis.SetIpConnection(redis_ip, redis_port);
+    } else {
+        DARWIN_LOG_ERROR("End:: Generator:: no valid way to connect to Redis, "
+                            "please set 'redis_socket_path' or 'redis_ip' (and optionally 'redis_port').");
+        return false;
+    }
     return redis.FindAndConnect();
 }
 

--- a/samples/fsession/Generator.cpp
+++ b/samples/fsession/Generator.cpp
@@ -34,22 +34,47 @@ bool Generator::LoadConfig(const rapidjson::Document &configuration) {
     DARWIN_LOGGER;
     DARWIN_LOG_DEBUG("Session:: Generator:: Loading configuration...");
 
-    std::string redis_socket_path;
+    std::string redis_socket_path, redis_ip;
+    unsigned int redis_port = 6379;
 
-    if (!configuration.HasMember("redis_socket_path")) {
-        DARWIN_LOG_CRITICAL("Session:: Generator:: Missing parameter: 'redis_socket_path'");
-        return false;
+    if(configuration.HasMember("redis_socket_path")) {
+        if (not configuration["redis_socket_path"].IsString()) {
+            DARWIN_LOG_CRITICAL("Session:: Generator:: 'redis_socket_path' needs to be a string");
+            return false;
+        } else {
+            redis_socket_path = configuration["redis_socket_path"].GetString();
+        }
     }
 
-    if (!configuration["redis_socket_path"].IsString()) {
-        DARWIN_LOG_CRITICAL("Session:: Generator:: 'redis_socket_path' needs to be a string");
-        return false;
+    if(configuration.HasMember("redis_ip")) {
+        if (not configuration["redis_ip"].IsString()) {
+            DARWIN_LOG_CRITICAL("Session:: Generator:: 'redis_ip' needs to be a string");
+            return false;
+        } else {
+            redis_ip = configuration["redis_ip"].GetString();
+        }
     }
 
-    redis_socket_path = configuration["redis_socket_path"].GetString();
+    if(configuration.HasMember("redis_port")) {
+        if (not configuration["redis_port"].IsUint()) {
+            DARWIN_LOG_CRITICAL("Session:: Generator:: 'redis_port' needs to be an unsigned integer");
+            return false;
+        } else {
+            redis_port = configuration["redis_port"].GetUint();
+        }
+    }
+
     darwin::toolkit::RedisManager& redis = darwin::toolkit::RedisManager::GetInstance();
     // Done in AlertManager before arriving here, but will allow better transition from redis singleton
-    redis.SetUnixConnection(redis_socket_path);
+    if (not redis_socket_path.empty()) {
+        redis.SetUnixConnection(redis_socket_path);
+    } else if (not redis_ip.empty()) {
+        redis.SetIpConnection(redis_ip, redis_port);
+    } else {
+        DARWIN_LOG_ERROR("Session:: Generator:: no valid way to connect to Redis, "
+                            "please set 'redis_socket_path' or 'redis_ip' (and optionally 'redis_port').");
+        return false;
+    }
     return redis.FindAndConnect();
 }
 

--- a/samples/ftest/Generator.cpp
+++ b/samples/ftest/Generator.cpp
@@ -34,48 +34,77 @@ bool Generator::ConfigureAlerting(const std::string& tags) {
 bool Generator::LoadConfig(const rapidjson::Document &configuration) {
     DARWIN_LOGGER;
     DARWIN_LOG_DEBUG("Test:: Generator:: Loading Configuration...");
-    std::string redis_socket_path;
+    std::string redis_socket_path, redis_ip;
+    unsigned int redis_port = 6379;
 
     if (configuration.HasMember("fail_config"))
         return false;
+
     if(configuration.HasMember("redis_socket_path")) {
-        if (configuration["redis_socket_path"].IsString()) {
+        if (not configuration["redis_socket_path"].IsString()) {
+            DARWIN_LOG_WARNING("Test:: Generator:: 'redis_socket_path' needs to be a string");
+        } else {
             redis_socket_path = configuration["redis_socket_path"].GetString();
-
-            if (configuration.HasMember("redis_list_name")){
-                if (configuration["redis_list_name"].IsString()) {
-                    _redis_list_name = configuration["redis_list_name"].GetString();
-                    DARWIN_LOG_INFO("Test:: Generator:: 'redis_list_name' set to " + _redis_list_name);
-                }
-            }
-
-            if (configuration.HasMember("redis_channel_name")){
-                if (configuration["redis_channel_name"].IsString()) {
-                    _redis_channel_name = configuration["redis_channel_name"].GetString();
-                    DARWIN_LOG_INFO("Test:: Generator:: 'redis_channel_name' set to " + _redis_channel_name);
-                }
-            }
-
-            if(not ConfigRedis(redis_socket_path)){
-                DARWIN_LOG_WARNING("Test:: Generator:: Error when configuring REDIS");
-                return true;
-            }
         }
-        else {
-            DARWIN_LOG_WARNING("Test:: Generator:: 'redis_socket_path' needs to be a string, ignoring");
+    }
+
+    if(configuration.HasMember("redis_ip")) {
+        if (not configuration["redis_ip"].IsString()) {
+            DARWIN_LOG_WARNING("Test:: Generator:: 'redis_ip' needs to be a string");
+        } else {
+            redis_ip = configuration["redis_ip"].GetString();
         }
+    }
+
+    if(configuration.HasMember("redis_port")) {
+        if (not configuration["redis_port"].IsUint()) {
+            DARWIN_LOG_WARNING("Test:: Generator:: 'redis_port' needs to be an unsigned integer");
+        } else {
+            redis_port = configuration["redis_port"].GetUint();
+        }
+    }
+
+    if (configuration.HasMember("redis_list_name")){
+        if (configuration["redis_list_name"].IsString()) {
+            _redis_list_name = configuration["redis_list_name"].GetString();
+            DARWIN_LOG_INFO("Test:: Generator:: 'redis_list_name' set to " + _redis_list_name);
+        }
+    }
+
+    if (configuration.HasMember("redis_channel_name")){
+        if (configuration["redis_channel_name"].IsString()) {
+            _redis_channel_name = configuration["redis_channel_name"].GetString();
+            DARWIN_LOG_INFO("Test:: Generator:: 'redis_channel_name' set to " + _redis_channel_name);
+        }
+    }
+
+
+    if(not ConfigRedis(redis_socket_path, redis_ip, redis_port)){
+        DARWIN_LOG_WARNING("Test:: Generator:: Error when configuring REDIS");
+        return true;
     }
 
     return true;
 }
 
-bool Generator::ConfigRedis(std::string redis_socket_path) {
+bool Generator::ConfigRedis(
+        const std::string& redis_socket_path,
+        const std::string& redis_ip,
+        unsigned int redis_port) {
     DARWIN_LOGGER;
     DARWIN_LOG_DEBUG("Test:: Generator:: Redis configuration...");
 
     darwin::toolkit::RedisManager& redis = darwin::toolkit::RedisManager::GetInstance();
     // Done in AlertManager before arriving here, but will allow better transition from redis singleton
-    redis.SetUnixConnection(redis_socket_path);
+    if (not redis_socket_path.empty()) {
+        redis.SetUnixConnection(redis_socket_path);
+    } else if (not redis_ip.empty()) {
+        redis.SetIpConnection(redis_ip, redis_port);
+    } else {
+        DARWIN_LOG_ERROR("Test:: Generator:: no valid way to connect to Redis, "
+                            "please set 'redis_socket_path' or 'redis_ip' (and optionally 'redis_port').");
+        return false;
+    }
     return redis.FindAndConnect();
 }
 

--- a/samples/ftest/Generator.hpp
+++ b/samples/ftest/Generator.hpp
@@ -32,7 +32,7 @@ protected:
     virtual bool ConfigureAlerting(const std::string& tags) override final;
 
 private:
-    bool ConfigRedis(std::string redis_socket_path);
+    bool ConfigRedis(const std::string& redis_socket_path, const std::string& redis_ip, unsigned int redis_port);
 
     std::string _redis_list_name;
     std::string _redis_channel_name;

--- a/tests/core/base.py
+++ b/tests/core/base.py
@@ -37,10 +37,9 @@ def check_start_stop():
 
     filter.configure(FTEST_CONFIG)
     filter.valgrind_start()
-    try:
-        kill(filter.process.pid, 0)
-    except OSError as e:
-        logging.error("check_start_stop: Process {} not running: {}".format(filter.process.pid, e))
+
+    if not filter.check_run():
+        logging.error("check_start_stop: Process {} not running".format(filter.process.pid))
         return False
 
     if filter.stop() is not True:

--- a/toolkit/RedisManager.cpp
+++ b/toolkit/RedisManager.cpp
@@ -84,7 +84,7 @@ namespace darwin {
 
             if(ConnectAddress(ip, port, &context)) {
                 reply = GetContextRole(context);
-                if(reply and strncmp(reply->element[0]->str, "master", 6)) {
+                if(reply and strncmp(reply->element[0]->str, "master", 6) == 0) {
                     ret = true;
                 }
                 freeReplyObject(reply);


### PR DESCRIPTION
# :sparkles: Redis improvements and fixes

## :page_with_curl: Type of change

Please delete options that are not relevant.

**Bug fix**: non-breaking change which fixes an issue.
**New feature**: non-breaking change which adds functionality.

## :bulb: Related Issue(s)

- none

## :black_nib: Description

### Fixed
- fbuffer: checks if key exists and is a SET (not a LIST) before potentially cleaning it at startup
- Redis Manager: TestIsManager(ip, port) logic was inverted
- Tests: `check_start_stop` did not check if filter is running properly

### Added
- Alert Manager: possibility to connect to Redis via IP:port
- fbuffer/fconnection/fend/fsession/ftanomaly/ftest: possibility to connect to Redis via IP:port

### TODO
- update documentation
- add tests for Redis through IP (at least in base tests)

## :dart: Test Environments

### FreeBSD (version)
- Redis (version)
- Boost (version)
- clang++ (or g++) (version)
- CMake (version)
- Python (version)

### Ubuntu (version)
- Redis (version)
- Boost (version)
- g++ (or clang++) (version)
- CMake (version)
- Python (version)
- Valgrind (version)

## :heavy_check_mark: Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] (**If new filter**) I have added corresponding page to the documentation
- [ ] (**If other changes**) I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

</br>

- [ ] :raising_hand: **I certify on my honor that all the information provided is true, and I've done all I can to deliver a high quality code**
