### PR TITLE
Change in boost package repository

### DIFF
--- a/docker/darwin
+++ b/docker/darwin
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get install -y\
  ca-certificates\
  && rm -rf /var/lib/apt/lists/*
 RUN BOOST_UNDERSCORE_VERSION=`echo ${BOOST_VERSION} | tr . _` \
- && wget https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/boost_${BOOST_UNDERSCORE_VERSION}.tar.gz \
+ && wget https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_UNDERSCORE_VERSION}.tar.gz \
  && mkdir boost \
  && tar xvf boost_${BOOST_UNDERSCORE_VERSION}.tar.gz -C boost --strip-components 1 \
  && cd boost \


### PR DESCRIPTION
# :sparkles: Change in boost package repository

## :page_with_curl: Type of change

**Breaking change**: fix or feature that would cause existing functionality to not work as expected.

## :bulb: Related Issue(s)

- no related issues

## :black_nib: Description

Jfrog has officially shutdown bintray and JCenter since Feb 3, 2021. So the resource `https://dl.bintray.com/` is not available. This PR changes the boost repository to the new official resource from `https://www.boost.org/`

## :dart: Test Environment

### Ubuntu (18.04.3 LTS)
- Docker(20.10.7 - community version)


## :heavy_check_mark: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] (**If new filter**) I have added corresponding page to the documentation
- [x] (**If other changes**) I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

</br>

- [x] :raising_hand: **I certify on my honor that all the information provided is true, and I've done all I can to deliver a high quality code**
