### PR TITLE
REDIS_MANAGER::CHANGED:: misleading log line during pings

### DIFF
--- a/toolkit/RedisManager.cpp
+++ b/toolkit/RedisManager.cpp
@@ -389,7 +389,7 @@ namespace darwin {
                 success = false;
             }
             else if(not reply){
-                DARWIN_LOG_WARNING("RedisManager::SendPing:: could not send ping");
+                DARWIN_LOG_DEBUG("RedisManager::SendPing:: no reply");
                 success = false;
             }
 


### PR DESCRIPTION
## :page_with_curl: Type of change

**CHANGE** [REDIS_MANAGER] [LOGGING] misleading log line during pings

## :bulb: Related Issue(s)

- none

## :black_nib: Description

One of the log lines from the Redis Manager left the user think Darwin didn't operate correctly with Redis, when the actual consequence was a lack of reply of Redis during a PING operation (result that do happen very regularly if a thread doesn't make any request to the Redis server and Redis closes the connexion on its end).

That log line has been taken down to DEBUG, and the line has been changed to avoid polluting logfiles and being misleading

## :dart: Test Environments
This change wasn't tested

## :heavy_check_mark: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] (**If new filter**) I have added corresponding page to the documentation
- [ ] (**If other changes**) I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

</br>

- [x] :raising_hand: **I certify on my honor that all the information provided is true, and I've done all I can to deliver a high quality code**
