### PR TITLE
LogRotation: Fixes on manager and filters

### DIFF
--- a/manager/manager.py
+++ b/manager/manager.py
@@ -14,7 +14,7 @@ import atexit
 import os
 from sys import exit
 from Services import Services
-from logging import FileHandler
+from logging.handlers import WatchedFileHandler
 from Administration import Server
 from threading import Thread, Condition
 from time import sleep
@@ -92,7 +92,7 @@ log_path = '{}/log{}/darwin_manager.log'.format(prefix, suffix)
 if not os.path.isfile(log_path):
     open(log_path, "a+").close()
 
-file_handler = FileHandler(log_path, mode="a+")
+file_handler = WatchedFileHandler(log_path, mode="a+")
 
 file_handler.setLevel(loglevel)
 file_handler.setFormatter(formatter)

--- a/samples/base/AlertManager.cpp
+++ b/samples/base/AlertManager.cpp
@@ -181,7 +181,8 @@ namespace darwin {
     }
 
     void AlertManager::Rotate() {
-        this->_log_file->Open(true);
+        if (this->_log)
+            this->_log_file->Open(true);
     }
 
     std::string AlertManager::FormatLog(const std::string& entry,

--- a/tests/core/base.py
+++ b/tests/core/base.py
@@ -1,9 +1,11 @@
 import logging
 import socket
-from os import kill, remove, access, F_OK
+from os import kill, remove, access, rename, F_OK
+from signal import SIGHUP
 from time import sleep
-from tools.filter import Filter
+from tools.filter import Filter, DEFAULT_LOG_FILE
 from tools.output import print_result
+from tools.darwin_utils import count_file_lines
 from core.utils import DEFAULT_PATH, FTEST_CONFIG, RESP_MON_STATUS_RUNNING
 from darwin import DarwinApi
 
@@ -26,6 +28,8 @@ def run():
         check_start_outbound_thread_num,
         check_start_outbound_cache_num,
         check_start_outbound_threshold_num,
+        check_write_logs,
+        check_rotate_logs,
     ]
 
     for i in tests:
@@ -261,6 +265,72 @@ def check_start_outbound_threshold_num():
     if filter.check_start():
         logging.error("check_start_outbound_threshold_num: Process started when threshold was out of bounds")
         filter.stop()
+        return False
+
+    return True
+
+def check_write_logs():
+    filter = Filter(filter_name="test")
+
+    filter.configure(FTEST_CONFIG)
+
+    init_lines = count_file_lines(DEFAULT_LOG_FILE)
+
+    filter.valgrind_start()
+    try:
+        kill(filter.process.pid, 0)
+    except OSError as e:
+        logging.error("check_write_logs: Process {} not running: {}".format(filter.process.pid, e))
+        return False
+
+    if filter.stop() is not True:
+        logging.error("check_write_logs: Process {} not stopping: {}".format(filter.process.pid, e))
+        return False
+
+    if init_lines == count_file_lines(DEFAULT_LOG_FILE):
+        logging.error("check_write_logs: filter didn't write any logs in logfile")
+        return False
+
+    return True
+
+def check_rotate_logs():
+    error = ""
+    filter = Filter(filter_name="test")
+
+    filter.configure(FTEST_CONFIG)
+
+    filter.valgrind_start()
+
+    # rename file to simulate log rotation
+    rename(DEFAULT_LOG_FILE, DEFAULT_LOG_FILE + ".moved")
+    # send rotate signal to filter
+    kill(filter.process.pid, SIGHUP)
+
+    lines_after_rotate = count_file_lines(DEFAULT_LOG_FILE + ".moved")
+
+    # send a line to filter to trigger writting to logfile
+    filter.send_single("test")
+
+    if count_file_lines(DEFAULT_LOG_FILE + ".moved") > lines_after_rotate:
+        error += "check_rotate_logs: new lines appended to old logfile"
+
+    if count_file_lines(DEFAULT_LOG_FILE) == 0:
+        error += "check_rotate_logs: no new lines written to new logfile"
+
+    remove(DEFAULT_LOG_FILE + ".moved")
+
+    if error:
+        logging.error(error)
+        return False
+
+    try:
+        kill(filter.process.pid, 0)
+    except OSError as e:
+        logging.error("check_rotate_logs: Process {} not running: {}".format(filter.process.pid, e))
+        return False
+
+    if filter.stop() is not True:
+        logging.error("check_rotate_logs: Process {} not stopping: {}".format(filter.process.pid, e))
         return False
 
     return True

--- a/tests/core/utils.py
+++ b/tests/core/utils.py
@@ -1,6 +1,8 @@
 from conf import DEFAULT_FILTER_PATH
+from tools.filter import DEFAULT_ALERTS_FILE
 
 
 DEFAULT_PATH = DEFAULT_FILTER_PATH + "darwin_logs"
 RESP_MON_STATUS_RUNNING = '"status": "running"'
-FTEST_CONFIG = '{"log_file_path": "/tmp/logs_test.log"}'
+FTEST_CONFIG = f'{{"log_file_path": "{DEFAULT_ALERTS_FILE}"}}'
+FTEST_CONFIG_NO_ALERT_LOG = '{}'

--- a/tests/manager_socket/logging_test.py
+++ b/tests/manager_socket/logging_test.py
@@ -1,0 +1,74 @@
+import logging
+from os import kill, rename, remove
+from signal import SIGHUP
+from manager_socket.utils import requests, CONF_EMPTY, REQ_MONITOR
+from tools.darwin_utils import darwin_configure, darwin_start, darwin_stop, darwin_remove_configuration, count_file_lines
+from tools.output import print_result
+from conf import TEST_FILES_DIR
+
+MANAGER_LOGFILE = TEST_FILES_DIR + "/log/darwin_manager.log"
+
+def run():
+    tests = [
+        check_write_logs,
+        check_rotate_logs,
+    ]
+
+    for i in tests:
+        print_result("Logging: " + i.__name__, i)
+
+
+def check_write_logs():
+    ret = True
+
+    try:
+        init_lines = count_file_lines(MANAGER_LOGFILE)
+    except:
+        init_lines = 0
+
+    darwin_configure(CONF_EMPTY)
+    process = darwin_start()
+
+    darwin_stop(process)
+    darwin_remove_configuration()
+
+    if init_lines == count_file_lines(MANAGER_LOGFILE):
+        logging.error("check_write_logs: manager didn't write a single line in expected logfile")
+        ret = False
+
+    return ret
+
+
+def check_rotate_logs():
+    ret = True
+
+    darwin_configure(CONF_EMPTY)
+    process = darwin_start()
+
+    rename(MANAGER_LOGFILE, MANAGER_LOGFILE + ".moved")
+    kill(process.pid, SIGHUP)
+    lines_after_rotate = count_file_lines(MANAGER_LOGFILE + ".moved")
+
+    resp = requests(REQ_MONITOR)
+    if resp == "":
+        logging.error("check_rotate_logs: manager didn't respond to monitoring query")
+        ret = False
+
+    darwin_stop(process)
+    darwin_remove_configuration()
+
+    if count_file_lines(MANAGER_LOGFILE + ".moved") > lines_after_rotate:
+        logging.error("check_rotate_logs: new lines were written to old logfile")
+        ret = False
+
+    try:
+        if count_file_lines(MANAGER_LOGFILE) == 0:
+            logging.error("check_rotate_logs: no new lines were written on file after rotation")
+            ret = False
+    except FileNotFoundError:
+        logging.error("check_rotate_logs: log file wasn't recreated by manager")
+        ret = False
+
+    remove(MANAGER_LOGFILE + ".moved")
+
+    return ret

--- a/tests/manager_socket/test.py
+++ b/tests/manager_socket/test.py
@@ -2,6 +2,7 @@ import pprint
 import manager_socket.monitor_test as monitor_test
 import manager_socket.update_test as update_test
 import manager_socket.reporting_test as reporting_test
+import manager_socket.logging_test as logging_test
 from tools.output import print_results
 
 def run():
@@ -10,6 +11,7 @@ def run():
     monitor_test.run()
     update_test.run()
     reporting_test.run()
+    logging_test.run()
 
     print()
     print()

--- a/tests/tools/darwin_utils.py
+++ b/tests/tools/darwin_utils.py
@@ -29,3 +29,7 @@ def darwin_configure(conf, path="{}/darwin.conf".format(TEST_FILES_DIR)):
 
 def darwin_remove_configuration(path="{}/darwin.conf".format(TEST_FILES_DIR)):
     os.remove(path)
+
+def count_file_lines(filepath):
+    with open(filepath, 'r') as file:
+        return len(file.readlines())

--- a/tests/tools/filter.py
+++ b/tests/tools/filter.py
@@ -11,6 +11,7 @@ from time import sleep
 from tools.redis_utils import RedisServer
 
 DEFAULT_LOG_FILE = "/var/log/darwin/darwin.log"
+DEFAULT_ALERTS_FILE = "/var/log/darwin/alerts.log"
 REDIS_SOCKET = "/tmp/redis.sock"
 REDIS_LIST_NAME = "darwin_tests"
 REDIS_CHANNEL_NAME = "darwin.tests"


### PR DESCRIPTION
## :page_with_curl: Type of change

Please delete options that are not relevant.

**Bug fix**: non-breaking change which fixes an issue.

## :bulb: Related Issue(s)

## :black_nib: Description

### Fixed
- [**MANAGER**][**LOGGING**] Use WatchedFileHandler to automatically reopen logging file after system logrotates
- [**CORE**][**ALERT_MANAGER**] Don't segfault on log rotation when no alert file was configured in filter's configuration

### Added
- [**TESTS**][**CORE**] Add tests to ensure proper logging, even after logrotation
- [**TESTS**][**CORE**] Add tests to ensure filters doesn't segfault after logrotation when filter is not configured with an alert log file
- [**TESTS**][**MANAGER**] Add tests to ensure proper logging, even after logrotation

## :dart: Test Environments

### HardenedBSD (12.2)
- Redis (6.2.6)
- Boost (1.72.0)
- clang++ (or g++) (10.3.0)
- CMake (3.22.1)
- Python (3.8.12)

### Ubuntu (20.04)
- Redis (5.0.7)
- Boost (1.71)
- g++ (or clang++) (9.3.0)
- CMake (3.16.3)
- Python (3.8.10)
- Valgrind (3.15.0)

## :heavy_check_mark: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

</br>

- [x] :raising_hand: **I certify on my honor that all the information provided is true, and I've done all I can to deliver a high-quality code**
