### PR TITLE
Session oauth check

### DIFF
--- a/samples/base/Session.cpp
+++ b/samples/base/Session.cpp
@@ -220,6 +220,7 @@ namespace darwin {
 
             if (!_body.IsArray()) {
                 DARWIN_LOG_ERROR("Session:: ParseBody: You must provide a list");
+                DARWIN_LOG_DEBUG("Session:: ParseBody: raw body is " + _raw_body);
                 return false;
             }
         } catch (...) {

--- a/samples/fsession/SessionTask.cpp
+++ b/samples/fsession/SessionTask.cpp
@@ -78,18 +78,6 @@ bool SessionTask::ReadFromSession(const std::string &token, const std::vector<st
     return REDISLookup(token, repo_ids) == 1;
 }
 
-std::string SessionTask::JoinRepoIDs(const std::vector<std::string> &repo_ids) {
-    std::string parsed_repo_ids;
-
-    for (auto it = repo_ids.begin(); it != repo_ids.end(); ++it) {
-        parsed_repo_ids += *it;
-
-        if (it != repo_ids.end() - 1) parsed_repo_ids += " ";
-    }
-
-    return parsed_repo_ids;
-}
-
 
 bool SessionTask::REDISResetExpire(const std::string &token, const std::string &repo_id) {
     DARWIN_LOGGER;

--- a/samples/fsession/SessionTask.cpp
+++ b/samples/fsession/SessionTask.cpp
@@ -49,7 +49,7 @@ void SessionTask::operator()() {
             SetStartingTime();
             unsigned int certitude;
 
-            certitude = ReadFromSession(_token, _repo_ids);
+            certitude = (REDISLookup(this->_token, this->_repo_ids) == 1);
             if(certitude)
                 STAT_MATCH_INC;
             _certitudes.push_back(certitude);
@@ -62,20 +62,6 @@ void SessionTask::operator()() {
             _certitudes.push_back(DARWIN_ERROR_RETURN);
         }
     }
-}
-
-bool SessionTask::ReadFromSession(const std::string &token, const std::vector<std::string> &repo_ids) noexcept {
-    DARWIN_LOGGER;
-
-    //Check that the session value has the expected length
-    if (token.size() != TOKEN_SIZE) {
-        DARWIN_LOG_ERROR("SessionTask::ReadFromSession:: Invalid token size: " + std::to_string(token.size()) +
-                         ". Expected size: " + std::to_string(TOKEN_SIZE));
-
-        return false;
-    }
-
-    return REDISLookup(token, repo_ids) == 1;
 }
 
 
@@ -154,15 +140,17 @@ unsigned int SessionTask::REDISLookup(const std::string &token, const std::vecto
 
 bool SessionTask::ParseLine(rapidjson::Value &line) {
     DARWIN_LOGGER;
+    std::string raw_repo_ids;
+
     _expiration = 0;
+    _token.clear();
+    _repo_ids.clear();
 
     if(not line.IsArray()) {
         DARWIN_LOG_ERROR("SessionTask:: ParseBody: The input line is not an array");
         return false;
     }
 
-    _token.clear();
-    _repo_ids.clear();
     auto values = line.GetArray();
 
     if (values.Size() <= 0) {
@@ -180,7 +168,7 @@ bool SessionTask::ParseLine(rapidjson::Value &line) {
     else if (values.Size() > 3) {
         DARWIN_LOG_ERROR(
                 "SessionTask:: ParseBody: You must provide at most three arguments per request: the token, "
-                "the repository ID and the expiration value to set to the token key"
+                "the repository ID and the expiration value to set to the key"
         );
 
         return false;
@@ -196,6 +184,14 @@ bool SessionTask::ParseLine(rapidjson::Value &line) {
                             "format: REPOSITORY1;REPOSITORY2;...");
         return false;
     }
+
+    _token = values[0].GetString();
+    if (_token.empty()) {
+        DARWIN_LOG_ERROR("SessionTask:: ParseBody: The token cannot be empty");
+        return false;
+    }
+    raw_repo_ids = values[1].GetString();
+    boost::split(_repo_ids, raw_repo_ids, [](char c) {return c == ';';});
 
     if (values.Size() == 3) {
         if (values[2].IsString()) {
@@ -214,10 +210,6 @@ bool SessionTask::ParseLine(rapidjson::Value &line) {
             return false;
         }
     }
-
-    _token = values[0].GetString();
-    std::string raw_repo_ids = values[1].GetString();
-    boost::split(_repo_ids, raw_repo_ids, [](char c) {return c == ';';});
 
     DARWIN_LOG_DEBUG("SessionTask:: ParseBody: Parsed request: " + _token + " | " + raw_repo_ids);
 

--- a/samples/fsession/SessionTask.hpp
+++ b/samples/fsession/SessionTask.hpp
@@ -9,7 +9,6 @@
 
 extern "C" {
 #include <hiredis/hiredis.h>
-#include <openssl/sha.h>
 }
 
 #include <iostream>
@@ -47,20 +46,11 @@ public:
     // You need to override the functor to compile and be executed by the thread
     void operator()() override;
 
-    // The maximum length of the session key (SHA-256 = 64 chars)
-    static constexpr unsigned int TOKEN_SIZE = (2*SHA256_DIGEST_LENGTH);
-
 protected:
     /// Return filter code
     long GetFilterCode() noexcept override;
 
 private:
-    /// Read header from the session and
-    /// call the method appropriate to the data type received.
-    ///
-    /// \return true on success, false otherwise.
-    bool ReadFromSession(const std::string &token, const std::vector<std::string> &repo_ids) noexcept;
-
     /// Reset the expiration of key(s) in Redis depending on cases
     /// will reset the expiration of key(s) <token>_<repo_id> with _expiration
     /// will reset the expiration of the key <token> with _expiration if current TTL is lower

--- a/samples/fsession/SessionTask.hpp
+++ b/samples/fsession/SessionTask.hpp
@@ -74,11 +74,6 @@ private:
     /// \return true on success, false otherwise.
     unsigned int REDISLookup(const std::string &token, const std::vector<std::string> &repo_ids) noexcept;
 
-    /// Concatenates our repository IDs into a string, separated with spaces.
-    ///
-    /// \return The concatenated string.
-    std::string JoinRepoIDs(const std::vector<std::string> &repo_ids);
-
     /// Parse a line of the body.
     bool ParseLine(rapidjson::Value &line) final;
 

--- a/tests/filters/fsession.py
+++ b/tests/filters/fsession.py
@@ -38,7 +38,7 @@ def run():
         input_param2_wrong_type,
         input_param3_wrong_type,
         input_param3_invalid,
-        input_invalid_token_length,
+        input_empty_token_invalid,
         input_ok_no_param3,
         input_ok_param3_int,
         input_ok_param3_string,
@@ -227,11 +227,11 @@ def input_param3_invalid():
         "expiration should be a valid positive number"
     ])
 
-def input_invalid_token_length():
-    return _input_tests("input_invalid_token_length",
-    data=[["12", "2"]],
-    expected_certitudes=[0],
-    expected_logs=["Invalid token size: 2. Expected size: 64"])
+def input_empty_token_invalid():
+    return _input_tests("input_empty_token_invalid",
+    data=[["", "2"]],
+    expected_certitudes=[101],
+    expected_logs=["The token cannot be empty"])
 
 def input_ok_no_param3():
     return _input_tests("input_ok_no_param3",

--- a/tests/filters/fsession.py
+++ b/tests/filters/fsession.py
@@ -39,6 +39,8 @@ def run():
         input_param3_wrong_type,
         input_param3_invalid,
         input_empty_token_invalid,
+        input_ok_token_length_12,
+        input_ok_token_length_80,
         input_ok_no_param3,
         input_ok_param3_int,
         input_ok_param3_string,
@@ -232,6 +234,16 @@ def input_empty_token_invalid():
     data=[["", "2"]],
     expected_certitudes=[101],
     expected_logs=["The token cannot be empty"])
+
+def input_ok_token_length_12():
+    return _input_tests("input_ok_token_length_12",
+    data=[["123456789012", "2"]],
+    expected_certitudes=[0])
+
+def input_ok_token_length_80():
+    return _input_tests("input_ok_token_length_80",
+    data=[["12345678901234567890123456789012345678901234567890123456789012345678901234567890", "2"]],
+    expected_certitudes=[0])
 
 def input_ok_no_param3():
     return _input_tests("input_ok_no_param3",

--- a/tests/filters/fsession.py
+++ b/tests/filters/fsession.py
@@ -192,7 +192,7 @@ def input_too_much_parameters():
     return _input_tests("input_too_much_parameters",
     data=[[1, 2, 3, 4]],
     expected_certitudes=[101],
-    expected_logs=["You must provide at most three arguments per request: the token, the repository ID and the expiration value to set to the token key"])
+    expected_logs=["You must provide at most three arguments per request: the token, the repository ID and the expiration value to set to the key"])
 
 def input_param1_wrong_type():
     return _input_tests("input_param1_wrong_type",


### PR DESCRIPTION
# :sparkles: Pull Request Template

## :page_with_curl: Type of change

**New feature**: non-breaking change which adds functionality.

## :bulb: Related Issue(s)

- None

## :black_nib: Description

This PR depends on #220.
The main goal of this PR is to have a more flexible way to check for tokens during session Authorization using Darwin.

### Removed
- [SESSION] Do not validate token length anymore
- [SESSION] [CODE] remove openssl dependency

### Changed
- [TESTS][SESSION] Update input_too_much_parameters test with updated log line check
- [TESTS][SESSION] Replace input_invalid_token_length with new input_empty_token_invalid test

### Added
- [SESSION] validate presence of a non-empty token value
- [TESTS](SESSION] 2 new tests to validate that filter now allows tokens with different lengths

## :dart: Test Environments

### FreeBSD (12.3--HBSD)
- Redis (6.2.6)
- Boost (1.72.0)
- or g++)(10.3.0)
- CMake (3.21.0)
- Python (3.8.13)

### Ubuntu (18.04)
- Redis (5.0.7)
- Boost (1.71.0)
- g++ (9.3.0)
- CMake (3.16.3)
- Python (3.8.10)
- Valgrind (3.15.0)

## :heavy_check_mark: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

</br>

- [x] :raising_hand: **I certify on my honor that all the information provided is true, and I've done all I can to deliver a high-quality code**
