### PR TITLE
Version 1.5.5

### DIFF
--- a/manager/Services.py
+++ b/manager/Services.py
@@ -170,12 +170,10 @@ class Services:
             logger.error("cannot start filter: " + str(e))
             filter['status'] = psutil.STATUS_DEAD
             return False
-        try:
-            p.wait(timeout=1)
-        except TimeoutExpired:
-            if filter['log_level'].lower() == "debug":
-                logger.debug("Debug mode enabled. Ignoring timeout at process startup.")
-            else:
+        if filter['log_level'].lower() != "debug":
+            try:
+                p.wait(timeout=10)
+            except TimeoutExpired:
                 logger.error("Error starting filter. Did not daemonize before timeout. Killing it.")
                 p.kill()
                 p.wait()

--- a/samples/base/Core.cpp
+++ b/samples/base/Core.cpp
@@ -85,9 +85,8 @@ namespace darwin {
 
     bool Core::SetLogLevel(std::string level){
         DARWIN_LOGGER;
-        if (level == "DEVELOPER"){
+        if (level == "DEVELOPER") {
             log.setLevel(logger::Debug);
-            DARWIN_LOG_DEBUG("Developer mode activated");
             daemon = false;
             return true;
         }
@@ -104,16 +103,21 @@ namespace darwin {
         // OPTIONS
         log.setLevel(logger::Warning); // Log level by default
         opt = -1;
-        while((opt = getopt(ac, av, ":l:h")) != -1)
+        while((opt = getopt(ac, av, ":l:hno:")) != -1)
         {
-            DARWIN_LOG_DEBUG("OPT : " + std::to_string(opt));
-            DARWIN_LOG_DEBUG("OPTIND : " + std::to_string(optind));
             switch(opt)
             {
+                case 'n':
+                    daemon = false;
+                    break;
+                case 'o':
+                    if (not log.setFilePath(optarg))
+                        return false;
+                    break;
                 case 'l':
                     log_level.assign(optarg);
                     if(!Core::SetLogLevel(log_level)){
-                        DARWIN_LOG_ERROR("Core:: Program Arguments:: Unknown log-level given");
+                        std::cerr << "Unknown log-level " << optarg << std::endl << std::endl;
                         Core::Usage();
                         return false;
                     }
@@ -121,21 +125,20 @@ namespace darwin {
                 case 'h':
                     Core::Usage();
                     return false;
-                    break;
                 case ':':
-                    DARWIN_LOG_ERROR("Core:: Program Arguments:: Missing option argument");
+                    std::cerr << "Missing an option argument for -" << (char)optopt << std::endl << std::endl;
                     Core::Usage();
                     return false;
                 case '?':
-                    DARWIN_LOG_ERROR("Core:: Program Arguments:: Unknown option");
+                    std::cerr << "Unknown option -" << (char)optopt << std::endl << std::endl;
                     Core::Usage();
                     return false;
             }
         }
 
         // After options we need 10 mandatory arguments
-        if(ac-optind < 10){
-            DARWIN_LOG_ERROR("Core:: Program Arguments:: Missing some parameters");
+        if (ac-optind < 10) {
+            std::cerr << "Missing some parameters" << std::endl << std::endl;
             Core::Usage();
             return false;
         }
@@ -160,10 +163,9 @@ namespace darwin {
     }
 
     void Core::Usage() {
-        std::cout << "Usage: ./darwin filter_name socket_path config_file" <<
-                  " monitoring_socket_path pid_file output next_filter_socket_path nb_thread "
-                  <<
-                  "cache_size threshold [OPTIONS]\n";
+        std::cout << "Usage: ./filter <filter_name> <socket_path> <config_file> "
+                  "<monitoring_socket_path> <pid_file> <output> <next_filter_socket_path> <nb_thread> "
+                  "<cache_size> <threshold> [OPTIONS]\n\n";
         std::cout
                 << "  filter_name\tSpecify the name of this filter in the logs\n";
         std::cout
@@ -183,14 +185,16 @@ namespace darwin {
         std::cout
                 << "  cache_size\tInteger specifying the cache's size\n";
         std::cout
-                << "  threshold\tInteger specifying the minimum certitude at which the filter will output a log."
-                   "If it's over 100, take the filter's default threshold\n";
+                << "  threshold\tInteger specifying the minimal certitude at which the filter will output an alert. "
+                   "If it's over 100, take the filter's default threshold (80)\n";
         std::cout << "\nOPTIONS\n";
-        std::cout << "  -l\tSet log level to [DEBUG|INFO|NOTICE|WARNING|ERROR|CRITICAL|DEVELOPER].\n"
-                  << "    \tDefault is WARNING."
-                  << "    \tNOTE: DEVELOPER mode does not create a daemon and sets log level to DEBUG."
+        std::cout << "  -o <logfilepath> \tSet custom log file path.\n";
+        std::cout << "  -n\t\t\tDon't daemonize, filter will stay attached to parent process.\n";
+        std::cout << "  -l\t\t\tSet log level to [DEBUG|INFO|NOTICE|WARNING|ERROR|CRITICAL|DEVELOPER].\n"
+                  << "    \t\t\tDefault is WARNING.\n"
+                  << "    \t\t\tNOTE: DEVELOPER mode deactivates daemonization and sets log level to DEBUG.\n"
                   << std::endl;
-        std::cout << "  -h\tPrint help" << std::endl;
+        std::cout << "  -h\t\t\tPrint help" << std::endl;
     }
 
     bool Core::WritePID() {

--- a/samples/base/Logger.cpp
+++ b/samples/base/Logger.cpp
@@ -18,18 +18,22 @@
 namespace darwin {
     namespace logger {
 
-        Logger::Logger() : _logLevel(Warning) {
-            _file = std::ofstream(DARWIN_LOG_FILE, std::ios::out | std::ios::app);
-            if (!_file.is_open())
-                std::clog << "Can't open log file " << DARWIN_LOG_FILE << std::endl;
+        Logger::~Logger() {
+            if (_file.is_open())
+                _file.close();
         }
 
-        Logger::~Logger() {
-            _file.close();
+        bool Logger::openLogFile() {
+            _file = std::ofstream(_filepath, std::ios::out | std::ios::app);
+            if (not _file.is_open()) {
+                std::clog << "Can't open log file " << _filepath << std::endl;
+                return false;
+            }
+            return true;
         }
 
         void Logger::log(log_type type, std::string const& logMsg) {
-            if (type < this->_logLevel || !_file.is_open())
+            if (type < this->_logLevel)
                 return;
 
             std::string date = darwin::time_utils::GetTime();
@@ -60,9 +64,12 @@ namespace darwin {
             fmt << "\"filter\":\"" << _name << "\",";
             fmt << "\"message\":\"" << logMsg << "\"";
             fmt << '}';
-            _fileMutex.lock();
-            _file << fmt.str().c_str() << std::endl;
-            _fileMutex.unlock();
+            if (not _file.is_open() and not this->openLogFile()) {
+                std::clog << fmt.str() << std::endl;
+            } else {
+                std::lock_guard lock(_fileMutex);
+                _file << fmt.str().c_str() << std::endl;
+            }
         }
 
         void Logger::setLevel(darwin::logger::log_type type) {
@@ -88,14 +95,33 @@ namespace darwin {
             _name = name;
         }
 
+        bool Logger::setFilePath(std::string const& filepath) {
+            bool ret = true;
+
+            std::ofstream testfile = std::ofstream(filepath, std::ios::out | std::ios::app);
+
+            if (!testfile.is_open()) {
+                std::clog << "Can't open log file " << filepath << std::endl;
+                ret = false;
+            } else {
+                _filepath = filepath;
+                _file.swap(testfile);
+            }
+
+            return ret;
+        }
+
         void Logger::RotateLogs() {
-            _fileMutex.lock();
-            _file.close();
-            _file = std::ofstream(DARWIN_LOG_FILE, std::ios::out | std::ios::app);
-            if (!_file.is_open())
-                std::clog << "Can't open log file " << DARWIN_LOG_FILE
-                            << std::endl;
-            _fileMutex.unlock();
+            std::lock_guard lock(_fileMutex);
+
+            if (_file.is_open())
+                _file.close();
+
+            _file = std::ofstream(_filepath, std::ios::out | std::ios::app);
+
+            if (!_file.is_open()) {
+                std::clog << "Can't open log file " << _filepath << std::endl;
+            }
         }
     }
 }

--- a/samples/base/Logger.hpp
+++ b/samples/base/Logger.hpp
@@ -16,9 +16,9 @@
 
 // Default log files
 
-#  ifndef DARWIN_LOG_FILE
-#   define DARWIN_LOG_FILE "/var/log/darwin/darwin.log"
-#  endif //!DARWIN_LOG_FILE
+#  ifndef DARWIN_DEFAULT_LOG_FILE
+#   define DARWIN_DEFAULT_LOG_FILE "/var/log/darwin/darwin.log"
+#  endif //!DARWIN_DEFAULT_LOG_FILE
 
 #  ifndef DARWIN_LOGGER
 #   define DARWIN_LOGGER darwin::logger::Logger& log = darwin::logger::Logger::instance()
@@ -100,16 +100,24 @@ namespace darwin {
             /// \param name The name to set as the module name.
             void setName(std::string const& name);
 
+            /// \brief Set the output logfile fullpath
+            /// \param filepath the fullpath to the logfile
+            bool setFilePath(std::string const& filepath);
+
             ///Rotate logs
             void RotateLogs();
 
         private:
             /// \brief This is the constructor of logger object.
             /// This constructor is private because only getLogger method can call it.
-            Logger();
+            Logger() : _logLevel(Warning) {};
 
             /// \brief This is the destructor of logger object.
             ~Logger();
+
+            /// \brief This function opens the log file to be used by the logger
+            /// \warning internal _file object should be closed before calling the function
+            bool openLogFile();
 
             /// \brief Copy operator.
             /// \param other, The logger to copy
@@ -125,6 +133,7 @@ namespace darwin {
 
         private:
             log_type _logLevel;
+            std::string _filepath = DARWIN_DEFAULT_LOG_FILE;
             std::ofstream _file;
             std::string _name;
             std::mutex _fileMutex;

--- a/samples/base/Session.cpp
+++ b/samples/base/Session.cpp
@@ -220,6 +220,7 @@ namespace darwin {
 
             if (!_body.IsArray()) {
                 DARWIN_LOG_ERROR("Session:: ParseBody: You must provide a list");
+                DARWIN_LOG_DEBUG("Session:: ParseBody: raw body is " + _raw_body);
                 return false;
             }
         } catch (...) {

--- a/samples/fpythonexample/python_example_filter/requirements.txt
+++ b/samples/fpythonexample/python_example_filter/requirements.txt
@@ -1,2 +1,2 @@
-numpy==1.16.4
+numpy==1.22.0
 python-sample-package==0.4.0

--- a/samples/fsession/SessionTask.hpp
+++ b/samples/fsession/SessionTask.hpp
@@ -9,7 +9,6 @@
 
 extern "C" {
 #include <hiredis/hiredis.h>
-#include <openssl/sha.h>
 }
 
 #include <iostream>
@@ -47,20 +46,11 @@ public:
     // You need to override the functor to compile and be executed by the thread
     void operator()() override;
 
-    // The maximum length of the session key (SHA-256 = 64 chars)
-    static constexpr unsigned int TOKEN_SIZE = (2*SHA256_DIGEST_LENGTH);
-
 protected:
     /// Return filter code
     long GetFilterCode() noexcept override;
 
 private:
-    /// Read header from the session and
-    /// call the method appropriate to the data type received.
-    ///
-    /// \return true on success, false otherwise.
-    bool ReadFromSession(const std::string &token, const std::vector<std::string> &repo_ids) noexcept;
-
     /// Reset the expiration of key(s) in Redis depending on cases
     /// will reset the expiration of key(s) <token>_<repo_id> with _expiration
     /// will reset the expiration of the key <token> with _expiration if current TTL is lower
@@ -73,11 +63,6 @@ private:
     ///
     /// \return true on success, false otherwise.
     unsigned int REDISLookup(const std::string &token, const std::vector<std::string> &repo_ids) noexcept;
-
-    /// Concatenates our repository IDs into a string, separated with spaces.
-    ///
-    /// \return The concatenated string.
-    std::string JoinRepoIDs(const std::vector<std::string> &repo_ids);
 
     /// Parse a line of the body.
     bool ParseLine(rapidjson::Value &line) final;

--- a/tests/filters/fsession.py
+++ b/tests/filters/fsession.py
@@ -38,7 +38,9 @@ def run():
         input_param2_wrong_type,
         input_param3_wrong_type,
         input_param3_invalid,
-        input_invalid_token_length,
+        input_empty_token_invalid,
+        input_ok_token_length_12,
+        input_ok_token_length_80,
         input_ok_no_param3,
         input_ok_param3_int,
         input_ok_param3_string,
@@ -192,7 +194,7 @@ def input_too_much_parameters():
     return _input_tests("input_too_much_parameters",
     data=[[1, 2, 3, 4]],
     expected_certitudes=[101],
-    expected_logs=["You must provide at most three arguments per request: the token, the repository ID and the expiration value to set to the token key"])
+    expected_logs=["You must provide at most three arguments per request: the token, the repository ID and the expiration value to set to the key"])
 
 def input_param1_wrong_type():
     return _input_tests("input_param1_wrong_type",
@@ -227,11 +229,21 @@ def input_param3_invalid():
         "expiration should be a valid positive number"
     ])
 
-def input_invalid_token_length():
-    return _input_tests("input_invalid_token_length",
-    data=[["12", "2"]],
-    expected_certitudes=[0],
-    expected_logs=["Invalid token size: 2. Expected size: 64"])
+def input_empty_token_invalid():
+    return _input_tests("input_empty_token_invalid",
+    data=[["", "2"]],
+    expected_certitudes=[101],
+    expected_logs=["The token cannot be empty"])
+
+def input_ok_token_length_12():
+    return _input_tests("input_ok_token_length_12",
+    data=[["123456789012", "2"]],
+    expected_certitudes=[0])
+
+def input_ok_token_length_80():
+    return _input_tests("input_ok_token_length_80",
+    data=[["12345678901234567890123456789012345678901234567890123456789012345678901234567890", "2"]],
+    expected_certitudes=[0])
 
 def input_ok_no_param3():
     return _input_tests("input_ok_no_param3",

--- a/tests/tools/filter.py
+++ b/tests/tools/filter.py
@@ -18,24 +18,30 @@ REDIS_CHANNEL_NAME = "darwin.tests"
 
 class Filter():
 
-    def __init__(self, path=None, config_file=None, filter_name="filter", socket_path=None, monitoring_socket_path=None, pid_file=None, output="NONE", next_filter_socket_path="no", nb_threads=1, cache_size=0, threshold=101, log_level="DEVELOPER"):
+    def __init__(self, path=None, config_file=None, filter_name="filter", socket_path=None, monitoring_socket_path=None, pid_file=None, output="NONE", next_filter_socket_path="no", nb_threads=1, cache_size=0, threshold=101, log_level="DEVELOPER", log_filepath=None):
         self.filter_name = filter_name
         self.socket = socket_path if socket_path else "{}/{}.sock".format(TEST_FILES_DIR, filter_name)
         self.config = config_file if config_file else "{}/{}.conf".format(TEST_FILES_DIR, filter_name)
         self.path = path if path else "{}darwin_{}".format(DEFAULT_FILTER_PATH, filter_name)
         self.monitor = monitoring_socket_path if monitoring_socket_path else "{}/{}_mon.sock".format(TEST_FILES_DIR, filter_name)
         self.pid = pid_file if pid_file else "{}/{}.pid".format(TEST_FILES_DIR, filter_name)
-        self.cmd = [self.path, "-l", log_level, self.filter_name, self.socket, self.config, self.monitor, self.pid, output, next_filter_socket_path, str(nb_threads), str(cache_size), str(threshold)]
         self.process = None
         self.error_code = 99 # For valgrind testing
         self.pubsub = None
+        self.log_level = log_level
+        self.output = output
+        self.nb_threads = nb_threads
+        self.cache_size = cache_size
+        self.threshold = threshold
+        self.next_filter_socket_path = next_filter_socket_path
+        self.log_filepath = log_filepath
         self.prepare_log_file()
 
     def prepare_log_file(self):
-        # TODO variabilize once path can be changed
-        self.log_file = open("/var/log/darwin/darwin.log", 'a+')
+        filepath = self.log_filepath if self.log_filepath else DEFAULT_LOG_FILE
+        self.log_file = open(filepath, 'a+')
         if self.log_file is None:
-            logging.error("Could not open darwin.log")
+            logging.error("Could not open log file {}".format(filepath))
             return False
 
     def __del__(self):
@@ -50,6 +56,13 @@ class Filter():
                 self.log_file.close()
         except AttributeError:
             pass
+
+    @property
+    def cmd(self):
+        if self.log_filepath is not None:
+            return [self.path, "-l", self.log_level, "-n", "-o", self.log_filepath, self.filter_name, self.socket, self.config, self.monitor, self.pid, self.output, self.next_filter_socket_path, str(self.nb_threads), str(self.cache_size), str(self.threshold)]
+        else:
+            return [self.path, "-l", self.log_level, "-n", self.filter_name, self.socket, self.config, self.monitor, self.pid, self.output, self.next_filter_socket_path, str(self.nb_threads), str(self.cache_size), str(self.threshold)]
 
     def check_start(self):
         if not os.path.exists(self.pid):
@@ -148,6 +161,11 @@ class Filter():
 
         try:
             os.remove(self.pid)
+        except:
+            pass
+
+        try:
+            os.remove(self.log_file)
         except:
             pass
 


### PR DESCRIPTION
## :page_with_curl: Type of change

Please delete options that are not relevant.

**Bug fix**: non-breaking change which fixes an issue.
**New feature**: non-breaking change which adds functionality.


## :black_nib: Description

### Security
- [PYTHON][DEPENDENCIES] bump numpy version to 1.22.0 (was 1.16.4) for python example filter

### Added
- [CORE] **-n**  parameter to keep filter from daemonizing
- [CORE] **-o <logfile>** parameter to direct logs to a different file
- [TESTS] test to check the **-o** parameter
- [SESSION] validate presence of a non-empty token value
- [TESTS][SESSION] 2 new tests to validate that filter now allows tokens with different lengths

### Changed
- [CORE] errors in parameters parsing are now directed to stderr
- [TESTS][SESSION] Update input_too_much_parameters test with updated log line check
- [TESTS][SESSION] Replace input_invalid_token_length with new input_empty_token_invalid test

### Fixed
- [MANAGER] wait long enough for a filter to start before declaring it dead

### Removed
- [SESSION] Do not validate token length anymore
- [SESSION] [CODE] remove openssl dependency

## :dart: Test Environments

### HardenedBSD (12.3-STABLE)
- Redis (6.2.6)
- Boost (1.72.0)
- clang++ (13.0.0)
- CMake (3.22.2)
- Python (3.8.13)

### Ubuntu (20.04)
- Redis (5.0.7)
- Boost (1.71.0)
- g++ (or clang++) (9.3.0)
- CMake (3.16.3)
- Python (3.8.10)
- Valgrind (3.15.0)

## :heavy_check_mark: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

</br>

- [x] :raising_hand: **I certify on my honor that all the information provided is true, and I've done all I can to deliver a high-quality code**
